### PR TITLE
Let documents.add() method return None

### DIFF
--- a/pycatia/in_interfaces/documents.py
+++ b/pycatia/in_interfaces/documents.py
@@ -48,7 +48,7 @@ class Documents(Collection):
         self.documents = com_object
         self.child_object = Document
 
-    def add(self, document_type) -> Document:
+    def add(self, document_type) -> None:
         """
         .. note::
             :class: toggle
@@ -92,7 +92,7 @@ class Documents(Collection):
 
         self.logger.info(f'Creating a new "{document_type}".')
 
-        return Document(self.child_object(self.documents.Add(document_type)))
+        Document(self.child_object(self.documents.Add(document_type)))
 
     def count_types(self, file_type_list: list_str) -> int:
         """


### PR DESCRIPTION
Currently, `documents.add()` method returns a improper Document object.
This leads problem in jupyter IDE.
When running code below in jupyter,
```
from pycatia import catia
caa = catia()
documents = caa.documents
documents.add('Part')
```
the IPython kernel would print last object in this cell. Then it raises an error.
The same problem occurs when we attempt to print this object in Terminal, like:
```
from pycatia import catia
caa = catia()
documents = caa.documents
doc = documents.add('Part')
print(doc)
```
I suggest we can just let `documents.add()` method return None, like built-in `list.append()`.
When we would always use `document = caa.active_document` to get the Document object, this change would be fine.