### PR TITLE
Amend document.export_data for argument 'overwrite'

### DIFF
--- a/pycatia/drafting_interfaces/drawing_sheet.py
+++ b/pycatia/drafting_interfaces/drawing_sheet.py
@@ -9,7 +9,6 @@
         
 """
 
-import os
 from pathlib import Path
 
 from pycatia.exception_handling.exceptions import CATIAApplicationException
@@ -538,14 +537,14 @@ class DrawingSheet(AnyObject):
         if not isinstance(file_name, Path):
             file_name = Path(file_name)
 
-        if str(file_name.parent) == '.':
-            self.logger.warning('Full path to print file expected. Assuming current working directory.')
-            file_name = Path(os.getcwd(), file_name)
+        # if str(file_name.parent) == '.':
+        #     self.logger.warning('Full path to print file expected. Assuming current working directory.')
+        #     file_name = Path(os.getcwd(), file_name)
 
         if not file_name.parent.is_dir():
             raise CATIAApplicationException(f'Directory {file_name.parent} does not exist.')
 
-        return self.drawing_sheet.PrintToFile(file_name)
+        return self.drawing_sheet.PrintToFile(file_name.absolute())
 
     def set_as_detail(self) -> None:
         """

--- a/pycatia/in_interfaces/document.py
+++ b/pycatia/in_interfaces/document.py
@@ -843,7 +843,7 @@ class Document(AnyObject):
             # if path_file_name.is_file():
             #     self.logger.warning('File already exists. Click YES in CATIA V5.')
 
-        self.document.SaveAs(path_file_name)
+        self.document.SaveAs(path_file_name.absolute())
         self.document.Application.DisplayFileAlerts = display_file_alerts_bool
 
     def search_for_items(self, selection_objects):

--- a/pycatia/in_interfaces/document.py
+++ b/pycatia/in_interfaces/document.py
@@ -515,7 +515,7 @@ class Document(AnyObject):
         # print("self.name:", self.name)
         # print("real_file_name: ", real_file_name)
         # print(file_type)
-        self.document.ExportData(real_file_name, file_type)
+        self.document.ExportData(real_file_name.absolute(), file_type)
         self.document.Application.DisplayFileAlerts = display_file_alerts_bool
 
     def indicate_2d(self, i_message: str, io_document_window_location: tuple) -> str:

--- a/pycatia/in_interfaces/document.py
+++ b/pycatia/in_interfaces/document.py
@@ -482,15 +482,19 @@ class Document(AnyObject):
         """
 
         real_file_name = Path(f"{file_name}.{file_type}")
+        display_file_alerts_bool = self.document.Application.DisplayFileAlerts
+
         if overwrite is False:
             if real_file_name.is_file():
                 raise FileExistsError(f'File: {real_file_name} already exists. '
                                       f'Set overwrite=True if you want to overwrite.')
         else:
-            if real_file_name.is_file():
-                self.logger.warning('File already exists. Click YES in CATIA V5.')
+            self.document.Application.DisplayFileAlerts = False
+            # if real_file_name.is_file():
+            #     self.logger.warning('File already exists. Click YES in CATIA V5.')
 
         self.document.ExportData(file_name, file_type)
+        self.document.Application.DisplayFileAlerts = display_file_alerts_bool
 
     def indicate_2d(self, i_message: str, io_document_window_location: tuple) -> str:
         """
@@ -778,7 +782,7 @@ class Document(AnyObject):
         """
         Save the document to a new name.
 
-        If overwrite is True CAA.DisplayFileAlerts is set to False.
+        If overwrite is True CAA.DisplayFileAlerts is set to False for temporary.
 
         .. note::
             :class: toggle
@@ -806,6 +810,7 @@ class Document(AnyObject):
         """
 
         path_file_name = Path(file_name)
+        display_file_alerts_bool = self.document.Application.DisplayFileAlerts
 
         if overwrite is False:
             if path_file_name.is_file():
@@ -817,6 +822,7 @@ class Document(AnyObject):
             #     self.logger.warning('File already exists. Click YES in CATIA V5.')
 
         self.document.SaveAs(path_file_name)
+        self.document.Application.DisplayFileAlerts = display_file_alerts_bool
 
     def search_for_items(self, selection_objects):
         """

--- a/pycatia/in_interfaces/document.py
+++ b/pycatia/in_interfaces/document.py
@@ -481,7 +481,26 @@ class Document(AnyObject):
         :return:
         """
 
-        real_file_name = Path(f"{file_name}.{file_type}")
+        # to get correct real_file_name
+        path_file_name = Path(file_name)
+        known_file_types = {'.CATPart', '.CATProduct', '.CATDrawing'}
+        if path_file_name.suffix.lower() == "." + file_type.lower():
+            real_file_name = path_file_name
+        elif path_file_name.suffix == "":
+            if path_file_name.is_dir():
+                real_file_name = (path_file_name.joinpath(self.name)).with_suffix('.' + file_type)
+            elif path_file_name.parent.is_dir():
+                real_file_name = path_file_name.with_suffix('.' + file_type)
+            else:
+                raise CATIAApplicationException(f'Directory {path_file_name.parent} does not exist.')
+        elif path_file_name.suffix in known_file_types:
+            # print("case3")
+            real_file_name = path_file_name.with_suffix('.' + file_type)
+        else:
+            # print("case6")
+            real_file_name = Path(f"{file_name}.{file_type}")
+
+        # to treat argument "overwrite"
         display_file_alerts_bool = self.document.Application.DisplayFileAlerts
 
         if overwrite is False:
@@ -492,8 +511,11 @@ class Document(AnyObject):
             self.document.Application.DisplayFileAlerts = False
             # if real_file_name.is_file():
             #     self.logger.warning('File already exists. Click YES in CATIA V5.')
-
-        self.document.ExportData(file_name, file_type)
+        # print("path_file_name", path_file_name)
+        # print("self.name:", self.name)
+        # print("real_file_name: ", real_file_name)
+        # print(file_type)
+        self.document.ExportData(real_file_name, file_type)
         self.document.Application.DisplayFileAlerts = display_file_alerts_bool
 
     def indicate_2d(self, i_message: str, io_document_window_location: tuple) -> str:


### PR DESCRIPTION
Likely #47, `document.export_data` amended.
When overwrite is set True, Application.DisplayFileAlerts is set False **for temporary**. It would be set back when method ends.
`document.save_as` does the same amend.