### PR TITLE
Provide Product.type property

### DIFF
--- a/pycatia/product_structure_interfaces/product.py
+++ b/pycatia/product_structure_interfaces/product.py
@@ -528,6 +528,18 @@ class Product(AnyObject):
         """
 
         self.product.Source = value
+    
+    @property
+    def type(self) -> str:
+        """
+        Return the type of product, catporduct, catpart or component
+        """
+        root_product_name = self.com_object.ReferenceProduct.Parent.Product.Name
+        self_product_name = self.com_object.ReferenceProduct.Name
+        if root_product_name == self_product_name:
+            return self.com_object.ReferenceProduct.Parent.Name.split('.')[-1].lower()
+        else:
+            return "component"
 
     @property
     def user_ref_properties(self) -> Parameters:

--- a/pycatia/product_structure_interfaces/product.py
+++ b/pycatia/product_structure_interfaces/product.py
@@ -532,14 +532,17 @@ class Product(AnyObject):
     @property
     def type(self) -> str:
         """
-        Return the type of product, catporduct, catpart or component
+        Returns the type of product (CATProduct, CATPart or Component).
+
+        :return: str
+        :rtype: str
         """
         root_product_name = self.com_object.ReferenceProduct.Parent.Product.Name
         self_product_name = self.com_object.ReferenceProduct.Name
         if root_product_name == self_product_name:
-            return self.com_object.ReferenceProduct.Parent.Name.split('.')[-1].lower()
+            return self.com_object.ReferenceProduct.Parent.Name.split('.')[-1]
         else:
-            return "component"
+            return "Component"
 
     @property
     def user_ref_properties(self) -> Parameters:


### PR DESCRIPTION
`Product.is_catpart` and `Product.is_catproduct` are wonderful methods. But it fails to distinguish *component* from *catproduct*.
`Product.type` make this function possible.