### PR TITLE
Method `get_tolerances` requires vba

### DIFF
--- a/pycatia/drafting_interfaces/drawing_dimension.py
+++ b/pycatia/drafting_interfaces/drawing_dimension.py
@@ -18,23 +18,23 @@ from pycatia.system_interfaces.any_object import AnyObject
 
 class DrawingDimension(AnyObject):
     """
-        .. note::
-            :class: toggle
+    .. note::
+        :class: toggle
 
-            CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
+        CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
 
-                | System.IUnknown
-                |     System.IDispatch
-                |         System.CATBaseUnknown
-                |             System.CATBaseDispatch
-                |                 System.AnyObject
-                |                     DrawingDimension
-                | 
-                | Represents a drawing dimension in a Drawing view.
-                | 
-                | Returns sub parts of dimension: Extension lines, dimension line and dimension
-                | value.
-    
+            | System.IUnknown
+            |     System.IDispatch
+            |         System.CATBaseUnknown
+            |             System.CATBaseDispatch
+            |                 System.AnyObject
+            |                     DrawingDimension
+            |
+            | Represents a drawing dimension in a Drawing view.
+            |
+            | Returns sub parts of dimension: Extension lines, dimension line and dimension
+            | value.
+
     """
 
     def __init__(self, com_object):
@@ -49,13 +49,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property CumulateMode() As boolean (Read Only)
-                | 
+                |
                 |     Returns cumulate mode or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves cumulate mode or not MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oCumulateMode = MyDimension.CumulateMode
 
         :return: bool
@@ -72,13 +72,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property DimStatus() As CatDimAnalyse (Read Only)
-                | 
+                |
                 |     Returns or sets status of dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves status of dimension MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oIsStatus = MyDimension.DimStatus
 
         :return: int
@@ -95,13 +95,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property DimType() As CatDimType (Read Only)
-                | 
+                |
                 |     Returns dimension type.
-                | 
+                |
                 |     Example:
                 |         This example retrieves the dimension type MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oTypeDim = MyDimension.DimType
 
         :return: int
@@ -118,13 +118,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property DualValue() As CatDimDualDisplay
-                | 
+                |
                 |     Returns or sets dual value type of dimension value.
-                | 
+                |
                 |     Example:
                 |         This example retrieves dual value type of dimension value MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oDualValue = MyDimension.DualValue
 
         :return: int
@@ -149,13 +149,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property Forshortened() As boolean
-                | 
+                |
                 |     Returns or sets foreshortened mode or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves foreshortened mode or not MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oForsh = MyDimension.Forshortened
 
         :return: bool
@@ -180,13 +180,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property HalfDimMode() As boolean
-                | 
+                |
                 |     Returns or sets half dimension mode or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves half dimension mode or not MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oHalfDimMode = MyDimension.HalfDimMode
 
         :return: bool
@@ -211,12 +211,12 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property IsClipped() As boolean (Read Only)
-                | 
+                |
                 |     Returns the clipping status of the dimension. Returns TRUE if the dimension
-                |     si clipped 
+                |     si clipped
                 | Example:
                 |     This example gets clipping status of MyDimension path.
-                | 
+                |
                 |      myDimensionClippingStatus=MyDimension.IsClipped
 
         :return: bool
@@ -233,13 +233,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property NbExtLine() As long (Read Only)
-                | 
+                |
                 |     Returns numbers of extension line of dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves numbers of extension line of dimension
                 |         MyDimension drawing dimension.
-                | 
+                |
                 |          oNbExtline = MyDimension.NbExtLine
 
         :return: int
@@ -256,13 +256,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property NbSymb() As long (Read Only)
-                | 
+                |
                 |     Returns numbers of symbol of dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves numbers of symbol of dimension MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oNbSymb = MyDimension.NbSymb
 
         :return: int
@@ -279,19 +279,19 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property Parameters() As Parameters (Read Only)
-                | 
+                |
                 |     Returns the collection of parameters of the dimension.
                 |     Warning: The returned parameters collection does not support adding
                 |     parameters, it is mainly provided to access dimension
                 |     value.
-                | 
+                |
                 |     Example:
-                | 
+                |
                 |           This example retrieves in DimensionParameters the collection
                 |           of
                 |          parameters currently managed by a dimension.
-                |          
-                | 
+                |
+                |
                 |          Dim DimensionParameters As Parameters
                 |          Set DimensionParameters = MyDimension.Parameters
                 |          Dim DimValueParameter As Parameter
@@ -311,15 +311,15 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property SymbolsSide() As long
-                | 
+                |
                 |     Returns or sets symbol side of dimension line. Legal values: 0 : Automatic positioning (Inside or
                 |     Outside). 1 : Symbols are inside. 2 : Symbols are outside. 3 : First symbol inside , second symbol
                 |     outside. 4 : First symbol outside, second symbol inside.
-                | 
+                |
                 |     Example:
                 |         This example retrieves symbol side of dimension line MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oSymbSide = MyDimension.SymbolsSide
 
         :return: int
@@ -344,13 +344,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property TrueDimMode() As boolean (Read Only)
-                | 
+                |
                 |     Returns or sets true dimension mode or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves true dimension mode or not MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oTrueDimMode = MyDimension.TrueDimMode
 
         :return: bool
@@ -366,13 +366,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueAngle() As double
-                | 
+                |
                 |     Returns or sets angle of dimension value.
-                | 
+                |
                 |     Example:
                 |         This example retrieves angle of dimension value MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oValueAng = MyDimension.ValueAngle
 
         :return: float
@@ -397,13 +397,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueAutoMode() As long
-                | 
+                |
                 |     Returns or sets auto mode of dimension value or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves auto mode of dimension value or not MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oValueAutoMode = MyDimension.ValueAutoMode
 
         :return: int
@@ -428,13 +428,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueDisplay() As long
-                | 
+                |
                 |     Returns or sets display of dimension value state.
-                | 
+                |
                 |     Example:
                 |         This example retrieves display of dimension value state MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oValueDisplay = MyDimension.ValueDisplay
 
         :return: int
@@ -459,13 +459,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueFrame() As CatDimFrame
-                | 
+                |
                 |     Returns or sets frame type of dimension value.
-                | 
+                |
                 |     Example:
                 |         This example retrieves frame type of dimension value MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oValueFrame = MyDimension.ValueFrame
 
         :return: int
@@ -490,13 +490,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueInOut() As long
-                | 
+                |
                 |     Returns or sets in/out mode of dimension value or not.
-                | 
+                |
                 |     Example:
                 |         This example retrieves in/out mode of dimension value or not
                 |         MyDimension drawing dimension.
-                | 
+                |
                 |          oInOut = MyDimension.ValueInOut
 
         :return: int
@@ -521,13 +521,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueOrientation() As CatDimOrientation
-                | 
+                |
                 |     Returns or sets orientation of dimension value.
-                | 
+                |
                 |     Example:
                 |         This example retrieves orientation of dimension value MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          oValueOrient = MyDimension.ValueOrientation
 
         :return: int
@@ -552,13 +552,13 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445)
                 | o Property ValueReference() As CatDimReference
-                | 
+                |
                 |     Returns or sets reference of dimension value.
-                | 
+                |
                 |     Example:
                 |         This example retrieves reference of dimension value MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          oValueRef = MyDimension.ValueReference
 
         :return: int
@@ -582,18 +582,18 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Sub GetBoundaryBox(CATSafeArrayVariant oValues)
-                | 
+                |
                 |     Get boundary box coordinates of dimension value.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         oValues
                 |             List of boundary box coordinates (X1,Y1,X2,Y2,.....X4,Y4).
-                |             
+                |
                 |         Example:
                 |             This example gets boundary box coordinates of MyDimension
                 |             path.
-                | 
+                |
                 |              MyDimension.GetBoundaryBox(oValues)
 
         :param tuple o_values:
@@ -601,7 +601,7 @@ class DrawingDimension(AnyObject):
         :rtype: None
         """
         return self.drawing_dimension.GetBoundaryBox(o_values)
-        # # # # Autogenerated comment: 
+        # # # # Autogenerated comment:
         # # some methods require a system service call as the methods expects a vb array object
         # # passed to it and there is no way to do this directly with python. In those cases the following code
         # # should be uncommented and edited accordingly. Otherwise completely remove all this.
@@ -626,24 +626,24 @@ class DrawingDimension(AnyObject):
                 | o Sub GetClip(double X,
                 | double Y,
                 | long oKeptSide)
-                | 
+                |
                 |     Gets informations of the dimension clipping. The value of this parameter
                 |     can be 1 or 2, and the kept side will be the one corresponding respectively to
                 |     ptldc1 and ptldc2 from GetGeomInfo method defined in CATIADrawingDimensionLine
                 |     idl interface. interface. If iKeptSide==0, there is no dimension
                 |     clipping.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         oX
-                |             X coordinate of position. 
+                |             X coordinate of position.
                 |         oY
-                |             Y coordinate of position. 
+                |             Y coordinate of position.
                 |         oKeptSide
                 |             returns the part of the dimension line will be clipped.
-                |             
+                |
                 |         Example:
-                | 
+                |
                 |              if MyDimension.IsClipped then
                 |                MyDimension.GetClip(X, Y, keptSide)
                 |              end if
@@ -663,18 +663,18 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Func GetDimExtLine() As DrawingDimExtLine
-                | 
+                |
                 |     Returns the drawing extension line of the drawing
                 |     dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves in DimExtLine extension line of the MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          Dim DimExtLine As DrawingDimExtLine
                 |          Set DimExtLine = MyDimension.GetDimExtLine
-                |          
-                | 
+                |
+                |
                 |     See also:
                 |         DrawingDimLine
 
@@ -690,18 +690,18 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Func GetDimLine() As DrawingDimLine
-                | 
+                |
                 |     Returns the drawing dimension line of the drawing
                 |     dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves in DimDimLine dimension line of the MyDimension
                 |         drawing dimension.
-                | 
+                |
                 |          Dim DimDimLine As DrawingDimLine
                 |          Set DimDimLine = MyDimension.GetDimLine
-                |          
-                | 
+                |
+                |
                 |     See also:
                 |         DrawingDimLine
 
@@ -710,14 +710,16 @@ class DrawingDimension(AnyObject):
         """
         return DrawingDimLine(self.drawing_dimension.GetDimLine())
 
-    def get_tolerances(self,
-                       o_tol_type: int,
-                       o_tol_name: str,
-                       o_up_tol: str,
-                       o_low_tol: str,
-                       od_up_tol: float,
-                       od_low_tol: float,
-                       o_display_mode: int) -> None:
+    def get_tolerances(
+        self,
+        o_tol_type: int,
+        o_tol_name: str,
+        o_up_tol: str,
+        o_low_tol: str,
+        od_up_tol: float,
+        od_low_tol: float,
+        o_display_mode: int,
+    ) -> None:
         """
         .. note::
             :class: toggle
@@ -730,29 +732,29 @@ class DrawingDimension(AnyObject):
                 | double odUpTol,
                 | double odLowTol,
                 | long oDisplayMode)
-                | 
+                |
                 |     Get tolerance information of dimension value.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         oTolType
-                |             Tolerance type 
+                |             Tolerance type
                 |         oTolName
-                |             Tolerance name 
+                |             Tolerance name
                 |         oUpTol
-                |             Upper tolerance value (alpha numerical type) 
+                |             Upper tolerance value (alpha numerical type)
                 |         oLowTol
-                |             Lower tolerance value (alpha numerical type) 
+                |             Lower tolerance value (alpha numerical type)
                 |         odUpTol
-                |             Upper tolerance value (numerical type) 
+                |             Upper tolerance value (numerical type)
                 |         odLowTol
-                |             Lower tolerance value (numerical type) 
+                |             Lower tolerance value (numerical type)
                 |         oDisplayMode
-                |             Tolerance display mode 
+                |             Tolerance display mode
                 |         Example:
                 |             This example gets tolerance information of MyDimension
                 |             path.
-                | 
+                |
                 |              MyDimension.GetTolerances(oTolType, oTolName, oUpTol, oLowTol,
                 |              odUpTol, odLowTol, oDisplayMode)
 
@@ -773,7 +775,7 @@ class DrawingDimension(AnyObject):
             o_low_tol,
             od_up_tol,
             od_low_tol,
-            o_display_mode
+            o_display_mode,
         )
 
     def get_value(self) -> DrawingDimValue:
@@ -783,17 +785,17 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Func GetValue() As DrawingDimValue
-                | 
+                |
                 |     Returns the drawing value of the drawing dimension.
-                | 
+                |
                 |     Example:
                 |         This example retrieves in DimDimValue value of the MyDimension drawing
                 |         dimension.
-                | 
+                |
                 |          Dim DimDimValue As DrawingDimValue
                 |          Set DimDimValue = MyDimension.GetValue
-                |          
-                | 
+                |
+                |
                 |     See also:
                 |         DrawingDimValue
 
@@ -802,7 +804,9 @@ class DrawingDimension(AnyObject):
         """
         return DrawingDimValue(self.drawing_dimension.GetValue())
 
-    def move_value(self, x: float, y: float, sub_part: int, dim_angle_behavior: int) -> None:
+    def move_value(
+        self, x: float, y: float, sub_part: int, dim_angle_behavior: int
+    ) -> None:
         """
         .. note::
             :class: toggle
@@ -812,15 +816,15 @@ class DrawingDimension(AnyObject):
                 | double Y,
                 | long SubPart,
                 | long DimAngleBehavior)
-                | 
+                |
                 |     Move dimension value.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         X
-                |             X coordinate of position. 
+                |             X coordinate of position.
                 |         Y
-                |             Y coordinate of position. 
+                |             Y coordinate of position.
                 |         SubPart
                 |             Defines which part of the dimension should be
                 |             moved.
@@ -832,15 +836,15 @@ class DrawingDimension(AnyObject):
                 |             4 = Secondary part and value
                 |             5 = Secondary part and dimension line
                 |             6 = Secondary part, dimension line and value
-                |             7 = Value leader (for dimension line with leader one part or two parts) 
+                |             7 = Value leader (for dimension line with leader one part or two parts)
                 |         DimAngleBehavior
                 |             Defines angle dimension line behavior.
                 |             0 = Sector angle is switched when ptPos is in opposite sector (Default)
-                |             1 = Sector angle is kept what ever ptPos placement 
+                |             1 = Sector angle is kept what ever ptPos placement
                 |         Example:
                 |             This example move dimension value MyDimension
                 |             path.
-                | 
+                |
                 |              MyDimension.MoveValue(X, Y, SubPart,
                 |              DimAngleBehavior)
 
@@ -860,12 +864,12 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Sub RestoreValuePosition()
-                | 
-                |     Restore dimension value position. 
+                |
+                |     Restore dimension value position.
                 | Example:
                 |     This example gets Restore dimension value position of MyDimension
                 |     path.
-                | 
+                |
                 |      MyDimension.RestoreValuePosition()
 
         :return: None
@@ -882,25 +886,25 @@ class DrawingDimension(AnyObject):
                 | o Sub SetClip(double X,
                 | double Y,
                 | long iKeptSide)
-                | 
+                |
                 |     Creates a clip on the dimension at the given point, with respect to the
                 |     side given by iKeptSide. The value of this parameter can be 1 or 2, and the
                 |     kept side will be the one corresponding respectively to ptldc1 and ptldc2 from
                 |     GetGeomInfo method defined in CATIADrawingDimensionLine idl interface.
                 |     interface.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         iX
-                |             X coordinate of position. 
+                |             X coordinate of position.
                 |         iY
-                |             Y coordinate of position. 
+                |             Y coordinate of position.
                 |         iKeptSide
                 |             Defines which part of the dimension should be kept.
-                |             
+                |
                 |         Example:
                 |             This example clips dimension MyDimension path.
-                | 
+                |
                 |              MyDimension.SetClip(X, Y, 1)
 
         :param float x:
@@ -911,14 +915,16 @@ class DrawingDimension(AnyObject):
         """
         return self.drawing_dimension.SetClip(x, y, i_kept_side)
 
-    def set_tolerances(self,
-                       i_tol_type: int,
-                       itol_name: str,
-                       i_up_tol: str,
-                       i_low_tol: str,
-                       id_up_tol: float,
-                       id_low_tol: float,
-                       display_mode: int) -> None:
+    def set_tolerances(
+        self,
+        i_tol_type: int,
+        itol_name: str,
+        i_up_tol: str,
+        i_low_tol: str,
+        id_up_tol: float,
+        id_low_tol: float,
+        display_mode: int,
+    ) -> None:
         """
         .. note::
             :class: toggle
@@ -931,29 +937,29 @@ class DrawingDimension(AnyObject):
                 | double idUpTol,
                 | double idLowTol,
                 | long DisplayMode)
-                | 
+                |
                 |     Set tolerance information of dimension value.
-                | 
+                |
                 |     Parameters:
-                | 
+                |
                 |         iTolType
-                |             Tolerance type 
+                |             Tolerance type
                 |         itolName
-                |             Tolerance name 
+                |             Tolerance name
                 |         iUpTol
-                |             Upper tolerance value (alpha numerical type) 
+                |             Upper tolerance value (alpha numerical type)
                 |         iLowTol
-                |             Lower tolerance value (alpha numerical type) 
+                |             Lower tolerance value (alpha numerical type)
                 |         idUpTol
-                |             Upper tolerance value (numerical type) 
+                |             Upper tolerance value (numerical type)
                 |         idLowTol
-                |             Lower tolerance value (numerical type) 
+                |             Lower tolerance value (numerical type)
                 |         DisplayMode
-                |             Tolerance display mode 
+                |             Tolerance display mode
                 |         Example:
                 |             This example sets tolerance information of MyDimension
                 |             path.
-                | 
+                |
                 |              MyDimension.SetTolerances(iTolType, itolName, iUpTol, iLowTol,
                 |              idUpTol, idLowTol, DisplayMode)
 
@@ -974,7 +980,7 @@ class DrawingDimension(AnyObject):
             i_low_tol,
             id_up_tol,
             id_low_tol,
-            display_mode
+            display_mode,
         )
 
     def unclip(self) -> None:
@@ -984,11 +990,11 @@ class DrawingDimension(AnyObject):
 
             CAA V5 Visual Basic Help (2020-06-11 12:40:47.360445))
                 | o Sub Unclip()
-                | 
-                |     Unclip the dimension if it is clipped. 
+                |
+                |     Unclip the dimension if it is clipped.
                 | Example:
                 |     This example unclip MyDimension path.
-                | 
+                |
                 |      if MyDimension.IsClipped then
                 |        MyDimension.Unclip
 

--- a/pycatia/drafting_interfaces/drawing_dimension.py
+++ b/pycatia/drafting_interfaces/drawing_dimension.py
@@ -9,6 +9,8 @@
         
 """
 
+from typing import Tuple
+
 from pycatia.drafting_interfaces.drawing_dim_ext_line import DrawingDimExtLine
 from pycatia.drafting_interfaces.drawing_dim_line import DrawingDimLine
 from pycatia.drafting_interfaces.drawing_dim_value import DrawingDimValue
@@ -710,16 +712,7 @@ class DrawingDimension(AnyObject):
         """
         return DrawingDimLine(self.drawing_dimension.GetDimLine())
 
-    def get_tolerances(
-        self,
-        o_tol_type: int,
-        o_tol_name: str,
-        o_up_tol: str,
-        o_low_tol: str,
-        od_up_tol: float,
-        od_low_tol: float,
-        o_display_mode: int,
-    ) -> None:
+    def get_tolerances(self) -> Tuple[int, str, str, str, float, float, int]:
         """
         .. note::
             :class: toggle
@@ -768,15 +761,27 @@ class DrawingDimension(AnyObject):
         :return: None
         :rtype: None
         """
-        return self.drawing_dimension.GetTolerances(
-            o_tol_type,
-            o_tol_name,
-            o_up_tol,
-            o_low_tol,
-            od_up_tol,
-            od_low_tol,
-            o_display_mode,
+        vba_function_name = "get_tolerances"
+        vba_code = """
+        Public Function get_tolerances(drawing_dimension)
+            Dim oValues(7)
+            drawing_dimension.GetTolerances tol_type, tol_name, tol_up_s, tol_low_s, tol_up_d, tol_low_d, tol_display
+
+            oValues(0) = tol_type
+            oValues(1) = tol_name
+            oValues(2) = tol_up_s
+            oValues(3) = tol_low_s
+            oValues(4) = tol_up_d
+            oValues(5) = tol_low_d
+            oValues(6) = tol_display
+
+            get_tolerances = oValues
+        End Function
+        """
+        value = self.application.system_service.evaluate(
+            vba_code, 0, vba_function_name, [self.com_object]
         )
+        return value[0], value[1], value[2], value[3], value[4], value[5], value[6]
 
     def get_value(self) -> DrawingDimValue:
         """

--- a/pycatia/part_interfaces/shape_factory.py
+++ b/pycatia/part_interfaces/shape_factory.py
@@ -8,6 +8,9 @@
         and thus help debugging in pycatia.
         
 """
+from pycatia.hybrid_shape_interfaces.hybrid_shape_symmetry import \
+    HybridShapeSymmetry
+from pycatia.in_interfaces.reference import Reference
 from pycatia.mec_mod_interfaces.body import Body
 from pycatia.mec_mod_interfaces.factory import Factory
 from pycatia.part_interfaces.add import Add
@@ -49,7 +52,6 @@ from pycatia.part_interfaces.user_pattern import UserPattern
 from pycatia.part_interfaces.var_rad_edge_fillet import VarRadEdgeFillet
 from pycatia.sketcher_interfaces.sketch import Sketch
 from pycatia.system_interfaces.any_object import AnyObject
-from pycatia.in_interfaces.reference import Reference
 
 
 class ShapeFactory(Factory):
@@ -2740,6 +2742,33 @@ class ShapeFactory(Factory):
         :rtype: UserPattern
         """
         return UserPattern(self.shape_factory.AddNewSurfacicUserPattern(i_shape_to_copy.com_object, i_nb_of_copies))
+
+    def add_new_symmetry_2(self, i_reference: Reference) -> HybridShapeSymmetry:
+        """
+        .. note::
+            :class: toggle
+
+            CAA V5 Visual Basic Help (2020-07-06 14:02:20.222384))
+                | o Func AddNewSymmetry2(Reference iReference) As HybridShapeSymmetry
+                | 
+                |     Creates a new Symmetry within the current body.
+                | 
+                |     Parameters:
+                |         
+                |     iReference
+                |         Point, line or reference plane.
+                |         Sub-element(s) supported (see Boundary object): see PlanarFace, Edge
+                |         and Vertex.
+                |     oSymmetry
+                |         Created symmetry.
+
+        :param Reference i_reference:
+        :return: HybridShapeSymmetry
+        :rtype: HybridShapeSymmetry
+        """
+        return HybridShapeSymmetry(
+            self.shape_factory.AddNewSymmetry2(i_reference.com_object)
+        )
 
     def add_new_thick_surface(self, i_offset_element: Reference, i_isens_offset: int, i_top_offset: float,
                               i_bot_offset: float) -> ThickSurface:


### PR DESCRIPTION
The `get_tolerances` method from the `drawing_dimension` module requires vba to return the parameters.
The function now returns a tuple, where the types match the param-types from the CATIA docs.

```python
def get_tolerances(self) -> Tuple[int, str, str, str, float, float, int]:
    vba_function_name = "get_tolerances"
    vba_code = """
    Public Function get_tolerances(drawing_dimension)
        Dim oValues(7)
        drawing_dimension.GetTolerances tol_type, tol_name, tol_up_s, tol_low_s, tol_up_d, tol_low_d, tol_display

        oValues(0) = tol_type
        oValues(1) = tol_name
        oValues(2) = tol_up_s
        oValues(3) = tol_low_s
        oValues(4) = tol_up_d
        oValues(5) = tol_low_d
        oValues(6) = tol_display

        get_tolerances = oValues
    End Function
    """
    value = self.application.system_service.evaluate(
        vba_code, 0, vba_function_name, [self.com_object]
    )
    return value[0], value[1], value[2], value[3], value[4], value[5], value[6]
```

Formatting is done because of the setup of my editor, hope it doesn't bother you.