### PR TITLE
in_interface fixes

### DIFF
--- a/pycatia/in_interfaces/selection.py
+++ b/pycatia/in_interfaces/selection.py
@@ -753,8 +753,7 @@ class Selection(AnyObject):
 
     def indicate_or_select_element_3d(self, i_planar_geometric_object: AnyObject, i_message: str, i_filter_type: tuple,
                                       i_object_selection_before_command_use_possibility: bool, i_tooltip: bool,
-                                      i_triggering_on_mouse_move: bool, o_object_selected: bool,
-                                      o_window_location_2d: tuple, o_window_location_3d: tuple) -> str:
+                                      i_triggering_on_mouse_move: bool) -> tuple:
         """
         .. note::
             :class: toggle
@@ -903,10 +902,25 @@ class Selection(AnyObject):
         :return: str
         :rtype: str
         """
-        return self.selection.IndicateOrSelectElement3D(i_planar_geometric_object.com_object, i_message, i_filter_type,
-                                                        i_object_selection_before_command_use_possibility, i_tooltip,
-                                                        i_triggering_on_mouse_move, o_object_selected,
-                                                        o_window_location_2d, o_window_location_3d)
+        vba_function_name = 'indicate_or_select_element_3d'
+        vba_code = f'''   
+        Public Function {vba_function_name}(selection, i_planar_geometric_object, i_message, i_filterType, i_object_selection_before_command_use_possibility, i_tooltip, i_triggering_on_mouse_move)
+        Dim o_object_selected
+        Dim o_window_location_2d (1)
+        Dim o_window_location_3d (2)
+        Dim o_output_state (3)
+        o_output_state (0) = selection.IndicateOrSelectElement3D(i_planar_geometric_object, i_message, i_filterType, i_object_selection_before_command_use_possibility, i_tooltip, i_triggering_on_mouse_move, o_object_selected, o_window_location_2d, o_window_location_3d)
+        o_output_state (1) = o_object_selected
+        o_output_state (2) = o_window_location_2d
+        o_output_state (3) = o_window_location_3d
+        {vba_function_name} = o_output_state
+        End Function
+        '''
+
+        system_service = self.application.system_service
+        result = system_service.evaluate(vba_code, 0, vba_function_name,[self.selection, i_planar_geometric_object.com_object, i_message, i_filter_type, i_object_selection_before_command_use_possibility, i_tooltip, i_triggering_on_mouse_move])
+        
+        return result
 
     def item(self, i_index: int) -> SelectedElement:
         """

--- a/pycatia/in_interfaces/vis_property_set.py
+++ b/pycatia/in_interfaces/vis_property_set.py
@@ -464,7 +464,7 @@ class VisPropertySet(AnyObject):
         :return: int
         :rtype: int
         """
-        return self.vis_property_set.GetShow()
+        return self.vis_property_set.GetShow()[1]
 
     def get_symbol_type(self) -> int:
         """


### PR DESCRIPTION
### indicate_or_select_element_3d
-changed required arguments to only inputs. 
-added system service call as the method expects VB-array objects passed to it.  
-changed return to tuple instead of string.

returns:
o_output_state [0]  = o_output_state  -> string. 
o_output_state [1] = o_object_selected -> boolean. 
o_output_state [2] = o_window_location_2d -> tuple. (x,y)  
o_output_state [3] = o_window_location_3d -> tuple. (x,y,z)