### PR TITLE
fix/tests

### DIFF
--- a/tests/create_source_drawing.py
+++ b/tests/create_source_drawing.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from pycatia.drafting_interfaces.drawing_document import DrawingDocument
 from pycatia.enumeration.enumeration_types import cat_paper_size
-from tests.common_vars import caa, test_files
+from tests.common_vars import caa
+from tests.common_vars import test_files
 from tests.create_source_parts import get_cat_part_measurable
 
 source_cat_drawing = Path(os.getcwd(), test_files, "drawing.CATDrawing")

--- a/tests/create_source_drawing.py
+++ b/tests/create_source_drawing.py
@@ -1,10 +1,10 @@
 import os
 from pathlib import Path
 
+from pycatia.drafting_interfaces.drawing_document import DrawingDocument
 from pycatia.enumeration.enumeration_types import cat_paper_size
+from tests.common_vars import caa, test_files
 from tests.create_source_parts import get_cat_part_measurable
-from tests.common_vars import caa
-from tests.common_vars import test_files
 
 source_cat_drawing = Path(os.getcwd(), test_files, "drawing.CATDrawing")
 
@@ -14,11 +14,11 @@ def create_cat_drawing():
     documents.add("Drawing")
     drawing_document = caa.active_document
     drawing_document.save_as(source_cat_drawing)
-    drawing = drawing_document.drawing_root
+    drawing = DrawingDocument(drawing_document.com_object).drawing_root
     sheets = drawing.sheets
 
     # open the cat part from which we'll be creating a front view.
-    documents.open(get_cat_part_measurable())
+    documents.open(str(get_cat_part_measurable()))
     document_product = caa.active_document
 
     # ################## #

--- a/tests/create_source_functional_system.py
+++ b/tests/create_source_functional_system.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 from pycatia.funct_system_interfaces.functional_document import FunctionalDocument
-
 from tests.common_vars import caa
 from tests.common_vars import test_files
 

--- a/tests/create_source_material.py
+++ b/tests/create_source_material.py
@@ -4,11 +4,11 @@ from tests.common_vars import caa
 
 
 def get_cat_material():
-    cat_startup_path = caa.application.system_service.environ('CATStartupPath')
-    cat_material_filename = 'Catalog.CATMaterial'
-    catpart_materials = Path(cat_startup_path, 'materials', cat_material_filename)
+    cat_startup_path = caa.application.system_service.environ("CATStartupPath")
+    cat_material_filename = "Catalog.CATMaterial"
+    catpart_materials = Path(cat_startup_path, "materials", cat_material_filename)
 
     if not catpart_materials.is_file():
-        raise FileNotFoundError(f'Could not find {catpart_materials}.')
+        raise FileNotFoundError(f"Could not find {catpart_materials}.")
 
     return catpart_materials

--- a/tests/create_source_parts.py
+++ b/tests/create_source_parts.py
@@ -1,11 +1,13 @@
 import os
 from pathlib import Path
 
-from pycatia.enumeration.enumeration_types import cat_constraint_mode, cat_constraint_type
+from pycatia.enumeration.enumeration_types import cat_constraint_mode
+from pycatia.enumeration.enumeration_types import cat_constraint_type
 from pycatia.in_interfaces.reference import Reference
 from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product_document import ProductDocument
-from tests.common_vars import caa, test_files
+from tests.common_vars import caa
+from tests.common_vars import test_files
 
 source_cat_part_measurable = Path(os.getcwd(), test_files, "part_measurable.CATPart")
 

--- a/tests/create_source_parts.py
+++ b/tests/create_source_parts.py
@@ -94,6 +94,11 @@ def create_cat_part_measurable(file_name):
     point_3 = hybrid_shape_factory.add_new_point_coord(pad_width, pad_height, 0)
     point_4 = hybrid_shape_factory.add_new_point_coord(0, pad_height, 0)
 
+    ref_point_1 = Reference(point_1.com_object)
+    ref_point_2 = Reference(point_2.com_object)
+    ref_point_3 = Reference(point_3.com_object)
+    ref_point_4 = Reference(point_4.com_object)
+
     # add the points to 'construction_points'
     hybrid_body_points.append_hybrid_shape(point_1)
     hybrid_body_points.append_hybrid_shape(point_2)
@@ -115,7 +120,8 @@ def create_cat_part_measurable(file_name):
     # create the sketch for the pad
     # #############################
     xy_plane = part.origin_elements.plane_xy
-    sketch = hybrid_body_sketches.hybrid_sketches.add(Reference(xy_plane.com_object))
+    ref_xy_plane = Reference(xy_plane.com_object)
+    sketch = hybrid_body_sketches.hybrid_sketches.add(ref_xy_plane)
     factory_2d = sketch.open_edition()
 
     # create the points for the lines.
@@ -145,52 +151,52 @@ def create_cat_part_measurable(file_name):
     con_line_1_start = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_1_2d.start_point.com_object),
-        Reference(point_1.com_object),
+        ref_point_1,
     )
     con_line_1_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_1_end = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_1_2d.end_point.com_object),
-        Reference(point_2.com_object),
+        ref_point_2,
     )
     con_line_1_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_2_start = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_2_2d.start_point.com_object),
-        Reference(point_2.com_object),
+        ref_point_2,
     )
     con_line_2_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_2_end = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_2_2d.end_point.com_object),
-        Reference(point_3.com_object),
+        ref_point_3,
     )
     con_line_2_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_3_start = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_3_2d.start_point.com_object),
-        Reference(point_3.com_object),
+        ref_point_3,
     )
     con_line_3_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_3_end = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_3_2d.end_point.com_object),
-        Reference(point_4.com_object),
+        ref_point_4,
     )
     con_line_3_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_4_start = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_4_2d.start_point.com_object),
-        Reference(point_4.com_object),
+        ref_point_4,
     )
     con_line_4_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_4_end = constraints.add_bi_elt_cst(
         cat_constraint_type.index("catCstTypeOn"),
         Reference(line_4_2d.end_point.com_object),
-        Reference(point_1.com_object),
+        ref_point_1,
     )
     con_line_4_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
@@ -209,10 +215,10 @@ def create_cat_part_measurable(file_name):
     # create lines
     # ##############
 
-    line_1 = hybrid_shape_factory.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_3.com_object))
+    line_1 = hybrid_shape_factory.add_new_line_pt_pt(ref_point_1, ref_point_3)
     hybrid_body_lines.append_hybrid_shape(line_1)
 
-    line_2 = hybrid_shape_factory.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_4.com_object))
+    line_2 = hybrid_shape_factory.add_new_line_pt_pt(ref_point_1, ref_point_4)
     hybrid_body_lines.append_hybrid_shape(line_2)
 
     # ###################################### #
@@ -226,9 +232,7 @@ def create_cat_part_measurable(file_name):
     # ################ #
     # create a circle  #
     # ################ #
-    circle = hybrid_shape_factory.add_new_circle_ctr_rad(
-        Reference(point_4.com_object), Reference(xy_plane.com_object), True, 25
-    )
+    circle = hybrid_shape_factory.add_new_circle_ctr_rad(ref_point_4, ref_xy_plane, True, 25)
     hybrid_body_arcs.append_hybrid_shape(circle)
 
     part.update()
@@ -269,7 +273,7 @@ def create_cat_part_measurable(file_name):
     # ############## #
     # create a plane #
     # ############## #
-    plane = hybrid_shape_factory.add_new_plane_offset(Reference(xy_plane.com_object), 200, True)
+    plane = hybrid_shape_factory.add_new_plane_offset(ref_xy_plane, 200, True)
     hybrid_body_planes.append_hybrid_shape(plane)
 
     part.update()
@@ -277,8 +281,8 @@ def create_cat_part_measurable(file_name):
     # ################# #
     # create a cylinder #
     # ################# #
-    direction = hybrid_shape_factory.add_new_direction(Reference(xy_plane.com_object))
-    cylinder = hybrid_shape_factory.add_new_cylinder(Reference(point_3.com_object), 33, 100, 0, direction)
+    direction = hybrid_shape_factory.add_new_direction(ref_xy_plane)
+    cylinder = hybrid_shape_factory.add_new_cylinder(ref_point_3, 33, 100, 0, direction)
     hybrid_body_cylinders.append_hybrid_shape(cylinder)
 
     part.update()

--- a/tests/create_source_parts.py
+++ b/tests/create_source_parts.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
 
-from pycatia.enumeration.enumeration_types import cat_constraint_mode
-from pycatia.enumeration.enumeration_types import cat_constraint_type
-from tests.common_vars import caa
-from tests.common_vars import test_files
+from pycatia.enumeration.enumeration_types import cat_constraint_mode, cat_constraint_type
+from pycatia.in_interfaces.reference import Reference
+from pycatia.mec_mod_interfaces.part_document import PartDocument
+from pycatia.product_structure_interfaces.product_document import ProductDocument
+from tests.common_vars import caa, test_files
 
 source_cat_part_measurable = Path(os.getcwd(), test_files, "part_measurable.CATPart")
 
@@ -24,12 +25,12 @@ def create_cat_part_measurable(file_name):
 
     document = caa.active_document
     document.save_as(file_name)
-    product = document.product
+    product = ProductDocument(document.com_object).product
     product.part_number = "cat_part_measurable"
     product.revision = "A.1"
     product.nomenclature = "pycatia part for testing"
     product.definition = "pycatia part for testing"
-    part = document.part
+    part = PartDocument(document.com_object).part
 
     pad_width = 100
     pad_height = 100
@@ -112,7 +113,7 @@ def create_cat_part_measurable(file_name):
     # create the sketch for the pad
     # #############################
     xy_plane = part.origin_elements.plane_xy
-    sketch = hybrid_body_sketches.hybrid_sketches.add(xy_plane)
+    sketch = hybrid_body_sketches.hybrid_sketches.add(Reference(xy_plane.com_object))
     factory_2d = sketch.open_edition()
 
     # create the points for the lines.
@@ -140,31 +141,55 @@ def create_cat_part_measurable(file_name):
     constraints = sketch.constraints
 
     con_line_1_start = constraints.add_bi_elt_cst(
-        cat_constraint_type.index("catCstTypeOn"), line_1_2d.start_point, point_1
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_1_2d.start_point.com_object),
+        Reference(point_1.com_object),
     )
     con_line_1_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
-    con_line_1_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_1_2d.end_point, point_2)
+    con_line_1_end = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_1_2d.end_point.com_object),
+        Reference(point_2.com_object),
+    )
     con_line_1_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_2_start = constraints.add_bi_elt_cst(
-        cat_constraint_type.index("catCstTypeOn"), line_2_2d.start_point, point_2
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_2_2d.start_point.com_object),
+        Reference(point_2.com_object),
     )
     con_line_2_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
-    con_line_2_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_2_2d.end_point, point_3)
+    con_line_2_end = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_2_2d.end_point.com_object),
+        Reference(point_3.com_object),
+    )
     con_line_2_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_3_start = constraints.add_bi_elt_cst(
-        cat_constraint_type.index("catCstTypeOn"), line_3_2d.start_point, point_3
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_3_2d.start_point.com_object),
+        Reference(point_3.com_object),
     )
     con_line_3_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
-    con_line_3_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_3_2d.end_point, point_4)
+    con_line_3_end = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_3_2d.end_point.com_object),
+        Reference(point_4.com_object),
+    )
     con_line_3_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     con_line_4_start = constraints.add_bi_elt_cst(
-        cat_constraint_type.index("catCstTypeOn"), line_4_2d.start_point, point_4
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_4_2d.start_point.com_object),
+        Reference(point_4.com_object),
     )
     con_line_4_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
-    con_line_4_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_4_2d.end_point, point_1)
+    con_line_4_end = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"),
+        Reference(line_4_2d.end_point.com_object),
+        Reference(point_1.com_object),
+    )
     con_line_4_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
     sketch.close_edition()
@@ -182,10 +207,10 @@ def create_cat_part_measurable(file_name):
     # create lines
     # ##############
 
-    line_1 = hybrid_shape_factory.add_new_line_pt_pt(point_1, point_3)
+    line_1 = hybrid_shape_factory.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_3.com_object))
     hybrid_body_lines.append_hybrid_shape(line_1)
 
-    line_2 = hybrid_shape_factory.add_new_line_pt_pt(point_1, point_4)
+    line_2 = hybrid_shape_factory.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_4.com_object))
     hybrid_body_lines.append_hybrid_shape(line_2)
 
     # ###################################### #
@@ -199,7 +224,9 @@ def create_cat_part_measurable(file_name):
     # ################ #
     # create a circle  #
     # ################ #
-    circle = hybrid_shape_factory.add_new_circle_ctr_rad(point_4, xy_plane, True, 25)
+    circle = hybrid_shape_factory.add_new_circle_ctr_rad(
+        Reference(point_4.com_object), Reference(xy_plane.com_object), True, 25
+    )
     hybrid_body_arcs.append_hybrid_shape(circle)
 
     part.update()
@@ -228,10 +255,10 @@ def create_cat_part_measurable(file_name):
     hybrid_body_points.append_hybrid_shape(point_8)
 
     spline = hybrid_shape_factory.add_new_spline()
-    spline.add_point(point_5)
-    spline.add_point(point_6)
-    spline.add_point(point_7)
-    spline.add_point(point_8)
+    spline.add_point(Reference(point_5.com_object))
+    spline.add_point(Reference(point_6.com_object))
+    spline.add_point(Reference(point_7.com_object))
+    spline.add_point(Reference(point_8.com_object))
 
     hybrid_body_splines.append_hybrid_shape(spline)
 
@@ -240,7 +267,7 @@ def create_cat_part_measurable(file_name):
     # ############## #
     # create a plane #
     # ############## #
-    plane = hybrid_shape_factory.add_new_plane_offset(xy_plane, 200, True)
+    plane = hybrid_shape_factory.add_new_plane_offset(Reference(xy_plane.com_object), 200, True)
     hybrid_body_planes.append_hybrid_shape(plane)
 
     part.update()
@@ -248,8 +275,8 @@ def create_cat_part_measurable(file_name):
     # ################# #
     # create a cylinder #
     # ################# #
-    direction = hybrid_shape_factory.add_new_direction(xy_plane)
-    cylinder = hybrid_shape_factory.add_new_cylinder(point_3, 33, 100, 0, direction)
+    direction = hybrid_shape_factory.add_new_direction(Reference(xy_plane.com_object))
+    cylinder = hybrid_shape_factory.add_new_cylinder(Reference(point_3.com_object), 33, 100, 0, direction)
     hybrid_body_cylinders.append_hybrid_shape(cylinder)
 
     part.update()

--- a/tests/create_source_parts.py
+++ b/tests/create_source_parts.py
@@ -101,8 +101,8 @@ def create_cat_part_measurable(file_name):
 
     relations = part.relations
     # the dim name here would typically be 'Part1\dim_width'. the com interfaces does not expect the 'Part1' part.
-    p_w_name = '\\'.join(dim_pad_width.name.split('\\')[1:])
-    p_h_name = '\\'.join(dim_pad_height.name.split('\\')[1:])
+    p_w_name = "\\".join(dim_pad_width.name.split("\\")[1:])
+    p_h_name = "\\".join(dim_pad_height.name.split("\\")[1:])
     formula_1 = relations.create_formula("formula_1", "", point_2.x, p_w_name)
     formula_2 = relations.create_formula("formula_2", "", point_3.x, p_w_name)
     formula_3 = relations.create_formula("formula_3", "", point_3.y, p_h_name)
@@ -139,26 +139,30 @@ def create_cat_part_measurable(file_name):
 
     constraints = sketch.constraints
 
-    con_line_1_start = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_1_2d.start_point,
-                                                  point_1)
+    con_line_1_start = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"), line_1_2d.start_point, point_1
+    )
     con_line_1_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_1_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_1_2d.end_point, point_2)
     con_line_1_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
-    con_line_2_start = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_2_2d.start_point,
-                                                  point_2)
+    con_line_2_start = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"), line_2_2d.start_point, point_2
+    )
     con_line_2_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_2_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_2_2d.end_point, point_3)
     con_line_2_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
-    con_line_3_start = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_3_2d.start_point,
-                                                  point_3)
+    con_line_3_start = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"), line_3_2d.start_point, point_3
+    )
     con_line_3_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_3_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_3_2d.end_point, point_4)
     con_line_3_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
 
-    con_line_4_start = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_4_2d.start_point,
-                                                  point_4)
+    con_line_4_start = constraints.add_bi_elt_cst(
+        cat_constraint_type.index("catCstTypeOn"), line_4_2d.start_point, point_4
+    )
     con_line_4_start.mode = cat_constraint_mode.index("catCstModeDrivingDimension")
     con_line_4_end = constraints.add_bi_elt_cst(cat_constraint_type.index("catCstTypeOn"), line_4_2d.end_point, point_1)
     con_line_4_end.mode = cat_constraint_mode.index("catCstModeDrivingDimension")

--- a/tests/create_source_products.py
+++ b/tests/create_source_products.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 from pywintypes import com_error
 
-from tests.common_vars import caa
-from tests.common_vars import test_files
+from pycatia.mec_mod_interfaces.part_document import PartDocument
+from pycatia.product_structure_interfaces.product_document import ProductDocument
+from tests.common_vars import caa, test_files
 from tests.create_source_parts import get_cat_part_measurable
 
 source_cat_product = Path(os.getcwd(), test_files, "product_top.CATProduct")
@@ -33,7 +34,7 @@ def create_cat_products(file_name_top, file_name_sub_1, file_name_sub_2):
     documents.add("Product")
     doc_root_prod = caa.active_document
     doc_root_prod.save_as(file_name_top)
-    product_top = doc_root_prod.product
+    product_top = ProductDocument(doc_root_prod.com_object).product
     product_top.part_number = "cat_product_1"
     product_top.revision = "A.1"
     product_top.nomenclature = "pycatia product for testing"
@@ -48,15 +49,15 @@ def create_cat_products(file_name_top, file_name_sub_1, file_name_sub_2):
     documents.add("Product")
     doc_sub_1 = caa.active_document
     doc_sub_1.save_as(file_name_sub_1)
-    product_sub_1 = doc_sub_1.product
+    product_sub_1 = ProductDocument(doc_sub_1.com_object).product
     product_sub_1.part_number = "cat_product_sub_1"
     product_sub_1.revision = "A.1"
     product_sub_1.nomenclature = "pycatia product for testing"
 
     products_sub_1 = product_sub_1.products
     cat_part_measurable = get_cat_part_measurable()
-    documents.open(cat_part_measurable)
-    doc_cat_part = caa.active_document
+    documents.open(str(cat_part_measurable))
+    doc_cat_part = PartDocument(caa.active_document.com_object)
     products_sub_1.add_component(doc_cat_part.product)
 
     doc_sub_1.save()
@@ -68,7 +69,7 @@ def create_cat_products(file_name_top, file_name_sub_1, file_name_sub_2):
     documents.add("Product")
     doc_sub_2 = caa.active_document
     doc_sub_2.save_as(file_name_sub_2)
-    product_sub_2 = doc_sub_2.product
+    product_sub_2 = ProductDocument(doc_sub_2.com_object).product
     product_sub_2.part_number = "cat_product_sub_2"
     product_sub_2.revision = "A.1"
     product_sub_2.nomenclature = "pycatia product for testing"
@@ -84,7 +85,7 @@ def create_cat_products(file_name_top, file_name_sub_1, file_name_sub_2):
 
     products.add_component(product_sub_1)
     products.add_component(product_sub_1)
-    products.add_component(product_sub_2)
+    products.add_component(product_sub_2)  # type: ignore
 
     # ################# #
     # Add new component #

--- a/tests/create_source_products.py
+++ b/tests/create_source_products.py
@@ -5,7 +5,8 @@ from pywintypes import com_error
 
 from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product_document import ProductDocument
-from tests.common_vars import caa, test_files
+from tests.common_vars import caa
+from tests.common_vars import test_files
 from tests.create_source_parts import get_cat_part_measurable
 
 source_cat_product = Path(os.getcwd(), test_files, "product_top.CATProduct")

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -5,8 +5,9 @@ co_ord_4 = (30, 5, 0)
 co_ord_5 = (40, 0, 0)
 
 
-def create_extrusion(part, hsf, hb, co_ord_1=co_ord_1, co_ord_2=co_ord_2, co_ord_3=co_ord_3, co_ord_4=co_ord_4,
-                     co_ord_5=co_ord_5):
+def create_extrusion(
+    part, hsf, hb, co_ord_1=co_ord_1, co_ord_2=co_ord_2, co_ord_3=co_ord_3, co_ord_4=co_ord_4, co_ord_5=co_ord_5
+):
     """
 
     :param hb:

--- a/tests/in/drafting/test_drawing.py
+++ b/tests/in/drafting/test_drawing.py
@@ -1,12 +1,13 @@
 #! /usr/bin/python3.6
 
 from pycatia import CATIADocHandler
-from pycatia.enumeration.enumeration_types import cat_drawing_standard
-from pycatia.enumeration.enumeration_types import cat_paper_orientation
-from pycatia.enumeration.enumeration_types import cat_sheet_projection_method
-from pycatia.enumeration.enumeration_types import cat_paper_size
+from pycatia.enumeration.enumeration_types import (
+    cat_drawing_standard,
+    cat_paper_orientation,
+    cat_paper_size,
+    cat_sheet_projection_method,
+)
 from tests.source_files import cat_drawing
-
 
 # todo: tests for parameters and relations
 
@@ -16,7 +17,7 @@ def test_active_drawing():
         catia = caa.catia
         drawing_root = catia.active_document.drawing_root
 
-        assert drawing_root.active_sheet.name == "Sheet.1"
+        assert drawing_root.active_sheet.name in ["Sheet.1", "Blatt .1"]  # TODO: Add more languages
 
 
 def test_orientation():

--- a/tests/in/drafting/test_drawing.py
+++ b/tests/in/drafting/test_drawing.py
@@ -16,7 +16,7 @@ def test_active_drawing():
         catia = caa.catia
         drawing_root = catia.active_document.drawing_root
 
-        assert drawing_root.active_sheet.name == 'Sheet.1'
+        assert drawing_root.active_sheet.name == "Sheet.1"
 
 
 def test_orientation():
@@ -25,9 +25,9 @@ def test_orientation():
         drawing_root = catia.active_document.drawing_root
         sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
-        assert sheet_1.orientation == cat_paper_orientation.index('catPaperLandscape')
+        assert sheet_1.orientation == cat_paper_orientation.index("catPaperLandscape")
         sheet_1.orientation = 0
-        assert sheet_1.orientation == cat_paper_orientation.index('catPaperPortrait')
+        assert sheet_1.orientation == cat_paper_orientation.index("catPaperPortrait")
 
 
 def test_paper_size():
@@ -36,9 +36,9 @@ def test_paper_size():
         drawing_root = catia.active_document.drawing_root
         sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
-        assert sheet_1.paper_size == cat_paper_size.index('catPaperA0')
+        assert sheet_1.paper_size == cat_paper_size.index("catPaperA0")
         sheet_1.paper_size = cat_paper_size.index("catPaperA1")
-        assert sheet_1.paper_size == cat_paper_size.index('catPaperA1')
+        assert sheet_1.paper_size == cat_paper_size.index("catPaperA1")
 
 
 def test_sheets():
@@ -46,14 +46,14 @@ def test_sheets():
         catia = caa.catia
         drawing_root = catia.active_document.drawing_root
         sheets = drawing_root.sheets
-        assert sheets.item(2).name == 'Sheet.2'
+        assert sheets.item(2).name == "Sheet.2"
 
 
 def test_standard():
     with CATIADocHandler(cat_drawing) as caa:
         catia = caa.catia
         root = catia.active_document.drawing_root
-        assert root.standard == cat_drawing_standard.index('catISO')
+        assert root.standard == cat_drawing_standard.index("catISO")
 
 
 def test_reorder():
@@ -69,8 +69,8 @@ def test_reorder():
 
         sheets = root.sheets
 
-        assert not sheets.item(1).name == 'Sheet.1'
-        assert sheets.item(1).name == 'Sheet.2'
+        assert not sheets.item(1).name == "Sheet.1"
+        assert sheets.item(1).name == "Sheet.2"
 
 
 def test_scale():
@@ -89,4 +89,4 @@ def test_projection_method():
         sheets = caa.catia.active_document.drawing_root.sheets
         sheet_1 = sheets.item(1)
 
-        assert sheet_1.projection_method == cat_sheet_projection_method.index('catFirstAngle')
+        assert sheet_1.projection_method == cat_sheet_projection_method.index("catFirstAngle")

--- a/tests/in/drafting/test_drawing.py
+++ b/tests/in/drafting/test_drawing.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from pycatia import CATIADocHandler
 from pycatia.drafting_interfaces.drawing_document import DrawingDocument

--- a/tests/in/drafting/test_drawing.py
+++ b/tests/in/drafting/test_drawing.py
@@ -2,12 +2,10 @@
 
 from pycatia import CATIADocHandler
 from pycatia.drafting_interfaces.drawing_document import DrawingDocument
-from pycatia.enumeration.enumeration_types import (
-    cat_drawing_standard,
-    cat_paper_orientation,
-    cat_paper_size,
-    cat_sheet_projection_method,
-)
+from pycatia.enumeration.enumeration_types import cat_drawing_standard
+from pycatia.enumeration.enumeration_types import cat_paper_orientation
+from pycatia.enumeration.enumeration_types import cat_paper_size
+from pycatia.enumeration.enumeration_types import cat_sheet_projection_method
 from tests.source_files import cat_drawing
 
 # todo: tests for parameters and relations

--- a/tests/in/drafting/test_drawing.py
+++ b/tests/in/drafting/test_drawing.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python3.6
 
 from pycatia import CATIADocHandler
+from pycatia.drafting_interfaces.drawing_document import DrawingDocument
 from pycatia.enumeration.enumeration_types import (
     cat_drawing_standard,
     cat_paper_orientation,
@@ -14,16 +15,14 @@ from tests.source_files import cat_drawing
 
 def test_active_drawing():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        drawing_root = catia.active_document.drawing_root
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
 
         assert drawing_root.active_sheet.name in ["Sheet.1", "Blatt .1"]  # TODO: Add more languages
 
 
 def test_orientation():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        drawing_root = catia.active_document.drawing_root
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
         sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
         assert sheet_1.orientation == cat_paper_orientation.index("catPaperLandscape")
@@ -33,8 +32,7 @@ def test_orientation():
 
 def test_paper_size():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        drawing_root = catia.active_document.drawing_root
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
         sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
         assert sheet_1.paper_size == cat_paper_size.index("catPaperA0")
@@ -44,31 +42,28 @@ def test_paper_size():
 
 def test_sheets():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        drawing_root = catia.active_document.drawing_root
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
         sheets = drawing_root.sheets
         assert sheets.item(2).name == "Sheet.2"
 
 
 def test_standard():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        root = catia.active_document.drawing_root
-        assert root.standard == cat_drawing_standard.index("catISO")
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
+        assert drawing_root.standard == cat_drawing_standard.index("catISO")
 
 
 def test_reorder():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        root = catia.active_document.drawing_root
-        sheets = root.sheets
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
+        sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
         sheet_2 = sheets.item(2)
 
         new_order = (sheet_2, sheet_1)
-        root.reorder_sheets(new_order)
+        drawing_root.reorder_sheets(new_order)
 
-        sheets = root.sheets
+        sheets = drawing_root.sheets
 
         assert not sheets.item(1).name == "Sheet.1"
         assert sheets.item(1).name == "Sheet.2"
@@ -76,9 +71,8 @@ def test_reorder():
 
 def test_scale():
     with CATIADocHandler(cat_drawing) as caa:
-        catia = caa.catia
-        root = catia.active_document.drawing_root
-        sheets = root.sheets
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
+        sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
         assert sheet_1.scale == 1.0
         sheet_1.scale = 2.0
@@ -87,7 +81,8 @@ def test_scale():
 
 def test_projection_method():
     with CATIADocHandler(cat_drawing) as caa:
-        sheets = caa.catia.active_document.drawing_root.sheets
+        drawing_root = DrawingDocument(caa.catia.active_document.com_object).drawing_root
+        sheets = drawing_root.sheets
         sheet_1 = sheets.item(1)
 
         assert sheet_1.projection_method == cat_sheet_projection_method.index("catFirstAngle")

--- a/tests/in/funct_system/test_functional_document.py
+++ b/tests/in/funct_system/test_functional_document.py
@@ -1,20 +1,24 @@
 import pytest
 
 from pycatia import CATIADocHandler
-from pycatia.funct_system_interfaces.functional_document import FunctionalDocument
 from pycatia.funct_system_interfaces.functional_description import FunctionalDescription
+from pycatia.funct_system_interfaces.functional_document import FunctionalDocument
 from tests.source_files import cat_functional_system
 
 
 def test_current_description():
     with CATIADocHandler(cat_functional_system) as caa:
-        functional_document = caa.document
+        document = caa.document
+        assert document is not None
 
+        functional_document = FunctionalDocument(document.com_object)
         assert functional_document.current_description.name == "Functional Document Description"
 
 
 def test_original_description():
     with CATIADocHandler(cat_functional_system) as caa:
-        functional_document = caa.document
+        document = caa.document
+        assert document is not None
 
+        functional_document = FunctionalDocument(document.com_object)
         assert functional_document.current_description.name == "Functional Document Description"

--- a/tests/in/funct_system/test_functional_document.py
+++ b/tests/in/funct_system/test_functional_document.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3.9
+
 import pytest
 
 from pycatia import CATIADocHandler

--- a/tests/in/hsf/test_hsf_circle.py
+++ b/tests/in/hsf/test_hsf_circle.py
@@ -11,7 +11,7 @@ def test_circle3_points():
     cord_2 = (130, 70, 0)
     cord_3 = (210, 50, 0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory

--- a/tests/in/hsf/test_hsf_circle.py
+++ b/tests/in/hsf/test_hsf_circle.py
@@ -1,4 +1,6 @@
 from pycatia import CATIADocHandler
+from pycatia.in_interfaces.reference import Reference
+from pycatia.mec_mod_interfaces.part_document import PartDocument
 
 
 def test_circle2_points_rad():
@@ -13,7 +15,9 @@ def test_circle3_points():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hbs = part.hybrid_bodies
@@ -28,7 +32,7 @@ def test_circle3_points():
         part.update()
 
         spa = document.spa_workbench()
-        measurable = spa.get_measurable(circle)
+        measurable = spa.get_measurable(Reference(circle.com_object))
 
         assert 158.597 == round(measurable.radius, 3)
 

--- a/tests/in/hsf/test_hsf_circle.py
+++ b/tests/in/hsf/test_hsf_circle.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3.9
+
 from pycatia import CATIADocHandler
 from pycatia.in_interfaces.reference import Reference
 from pycatia.mec_mod_interfaces.part_document import PartDocument

--- a/tests/in/hsf/test_hsf_lines.py
+++ b/tests/in/hsf/test_hsf_lines.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from pycatia.base_interfaces.context import CATIADocHandler
 from pycatia.in_interfaces.reference import Reference

--- a/tests/in/hsf/test_hsf_lines.py
+++ b/tests/in/hsf/test_hsf_lines.py
@@ -32,7 +32,7 @@ def test_line_point_point():
     co_ord_1 = (0, 0, 0)
     co_ord_2 = (length, 0, 0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory

--- a/tests/in/hsf/test_hsf_lines.py
+++ b/tests/in/hsf/test_hsf_lines.py
@@ -1,6 +1,8 @@
 #! /usr/bin/python3.6
 
 from pycatia.base_interfaces.context import CATIADocHandler
+from pycatia.in_interfaces.reference import Reference
+from pycatia.mec_mod_interfaces.part_document import PartDocument
 
 
 def test_line_angle():
@@ -34,7 +36,9 @@ def test_line_point_point():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -46,7 +50,7 @@ def test_line_point_point():
         gs_new.append_hybrid_shape(point_1)
         gs_new.append_hybrid_shape(point_2)
 
-        line = hsf.add_new_line_pt_pt(point_1, point_2)
+        line = hsf.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_2.com_object))
 
         gs_new.append_hybrid_shape(line)
 

--- a/tests/in/hsf/test_hsf_points.py
+++ b/tests/in/hsf/test_hsf_points.py
@@ -8,7 +8,7 @@ def test_point_between():
     co_ord_2 = (100, 0, 0)
     r = (50, 0, 0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -37,7 +37,7 @@ def test_point_center():
     co_ord_2 = (length, 0, 0)
     center = (length / 2, 0, 0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -66,7 +66,7 @@ def test_point_center():
 def test_point_coord():
     co_ord = (0, 10, 100)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -86,7 +86,7 @@ def test_point_coord_reference():
     co_ord = (0.0, 10.0, 100.0)
     r = tuple([i + i for i in co_ord])
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -120,7 +120,7 @@ def test_point_on_curve():
     co_ord_2 = (length, 0, 0)
     center = (length / 2, 0, 0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -143,10 +143,7 @@ def test_point_on_curve():
         line_ref = part.create_reference_from_object(line)
         direction = hsf.add_new_direction(line_ref)
 
-        point_center = hsf.add_new_point_on_curve_along_direction(line,
-                                                                  length / 2,
-                                                                  0,
-                                                                  direction)
+        point_center = hsf.add_new_point_on_curve_along_direction(line, length / 2, 0, direction)
 
         gs_new.append_hybrid_shape(point_center)
 
@@ -173,7 +170,7 @@ def test_point_curve_from_percent():
 def test_point_on_plane():
     co_ord_1 = (250.0, 100.0)
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory
@@ -194,12 +191,8 @@ def test_point_on_plane():
 def test_point_on_plane_reference():
     co_ord_1 = (250, 100, 0)
     co_ord_2 = (100, 200)
-    r = (
-        co_ord_1[0] + co_ord_2[0],
-        co_ord_1[1] + co_ord_2[1],
-        co_ord_1[2]
-    )
-    with CATIADocHandler(new_document='Part') as caa:
+    r = (co_ord_1[0] + co_ord_2[0], co_ord_1[1] + co_ord_2[1], co_ord_1[2])
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         hsf = part.hybrid_shape_factory

--- a/tests/in/hsf/test_hsf_points.py
+++ b/tests/in/hsf/test_hsf_points.py
@@ -1,6 +1,8 @@
 #! /usr/bin/python3.6
 
 from pycatia import CATIADocHandler
+from pycatia.in_interfaces.reference import Reference
+from pycatia.mec_mod_interfaces.part_document import PartDocument
 
 
 def test_point_between():
@@ -10,7 +12,9 @@ def test_point_between():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -22,7 +26,7 @@ def test_point_between():
         cg_points.append_hybrid_shape(point_1)
         cg_points.append_hybrid_shape(point_2)
 
-        point_between = hsf.add_new_point_between(point_1, point_2, 0.5, 0)
+        point_between = hsf.add_new_point_between(Reference(point_1.com_object), Reference(point_2.com_object), 0.5, 0)
 
         cg_points.append_hybrid_shape(point_between)
 
@@ -39,7 +43,9 @@ def test_point_center():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -51,11 +57,11 @@ def test_point_center():
 
         xy_plane = part.origin_elements.plane_xy
 
-        circle = hsf.add_new_circle_ctr_rad(point, xy_plane, True, 50)
+        circle = hsf.add_new_circle_ctr_rad(Reference(point.com_object), Reference(xy_plane.com_object), True, 50)
 
         gs_new.append_hybrid_shape(circle)
 
-        point_center = hsf.add_new_point_center(circle)
+        point_center = hsf.add_new_point_center(Reference(circle.com_object))
         gs_new.append_hybrid_shape(point_center)
 
         part.update()
@@ -68,7 +74,9 @@ def test_point_coord():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -88,7 +96,9 @@ def test_point_coord_reference():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -96,7 +106,9 @@ def test_point_coord_reference():
 
         org_point = hsf.add_new_point_coord(co_ord[0], co_ord[1], co_ord[2])
         cg_points.append_hybrid_shape(org_point)
-        point_1 = hsf.add_new_point_coord_with_reference(co_ord[0], co_ord[1], co_ord[2], org_point)
+        point_1 = hsf.add_new_point_coord_with_reference(
+            co_ord[0], co_ord[1], co_ord[2], Reference(org_point.com_object)
+        )
         cg_points.append_hybrid_shape(point_1)
 
         part.update()
@@ -122,7 +134,9 @@ def test_point_on_curve():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -134,7 +148,7 @@ def test_point_on_curve():
         gs_new.append_hybrid_shape(point_1)
         gs_new.append_hybrid_shape(point_2)
 
-        line = hsf.add_new_line_pt_pt(point_1, point_2)
+        line = hsf.add_new_line_pt_pt(Reference(point_1.com_object), Reference(point_2.com_object))
 
         gs_new.append_hybrid_shape(line)
 
@@ -143,7 +157,9 @@ def test_point_on_curve():
         line_ref = part.create_reference_from_object(line)
         direction = hsf.add_new_direction(line_ref)
 
-        point_center = hsf.add_new_point_on_curve_along_direction(line, length / 2, 0, direction)
+        point_center = hsf.add_new_point_on_curve_along_direction(
+            Reference(line.com_object), length / 2, False, direction
+        )
 
         gs_new.append_hybrid_shape(point_center)
 
@@ -172,14 +188,16 @@ def test_point_on_plane():
 
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
         gs_new = hybrid_bodies.add()
 
         xy_plane = part.origin_elements.plane_xy
-        point = hsf.add_new_point_on_plane(xy_plane, co_ord_1[0], co_ord_1[1])
+        point = hsf.add_new_point_on_plane(Reference(xy_plane.com_object), co_ord_1[0], co_ord_1[1])
 
         gs_new.append_hybrid_shape(point)
 
@@ -194,7 +212,9 @@ def test_point_on_plane_reference():
     r = (co_ord_1[0] + co_ord_2[0], co_ord_1[1] + co_ord_2[1], co_ord_1[2])
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
 
         hybrid_bodies = part.hybrid_bodies
@@ -205,7 +225,9 @@ def test_point_on_plane_reference():
 
         gs_new.append_hybrid_shape(org_point)
 
-        point = hsf.add_new_point_on_plane_with_reference(xy_plane, org_point, co_ord_2[0], co_ord_2[1])
+        point = hsf.add_new_point_on_plane_with_reference(
+            Reference(xy_plane.com_object), Reference(org_point.com_object), co_ord_2[0], co_ord_2[1]
+        )
 
         gs_new.append_hybrid_shape(point)
 

--- a/tests/in/hsf/test_hsf_points.py
+++ b/tests/in/hsf/test_hsf_points.py
@@ -209,7 +209,11 @@ def test_point_on_plane():
 def test_point_on_plane_reference():
     co_ord_1 = (250, 100, 0)
     co_ord_2 = (100, 200)
-    r = (co_ord_1[0] + co_ord_2[0], co_ord_1[1] + co_ord_2[1], co_ord_1[2])
+    r = (
+        co_ord_1[0] + co_ord_2[0],
+        co_ord_1[1] + co_ord_2[1],
+        co_ord_1[2],
+    )
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         assert document is not None

--- a/tests/in/hsf/test_hsf_points.py
+++ b/tests/in/hsf/test_hsf_points.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from pycatia import CATIADocHandler
 from pycatia.in_interfaces.reference import Reference

--- a/tests/in/knowledgeware/test_knowledgeware_parameters.py
+++ b/tests/in/knowledgeware/test_knowledgeware_parameters.py
@@ -18,7 +18,7 @@ def test_parameters_name():
 
         first_parameter = parameters.item(1)
 
-        assert first_parameter.name == r'cat_part_measurable\PartBody\Pad.1\FirstLimit\Length'
+        assert first_parameter.name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
 
 
 def test_all_parameters():
@@ -29,58 +29,58 @@ def test_all_parameters():
 
         all_parms = parameters.all_parameters()
 
-        assert all_parms[0].name == r'cat_part_measurable\PartBody\Pad.1\FirstLimit\Length'
+        assert all_parms[0].name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
 
 
 def test_create_boolean():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_boolean_parm = parameters.create_boolean('new_boolean', True)
+        new_boolean_parm = parameters.create_boolean("new_boolean", True)
 
-        assert new_boolean_parm.name == rf'{part.name}\new_boolean'
+        assert new_boolean_parm.name == rf"{part.name}\new_boolean"
         assert new_boolean_parm.value is True
 
 
 def test_create_dimension():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_dimension_parm = parameters.create_dimension('new_dimension', "length", 30.1)
+        new_dimension_parm = parameters.create_dimension("new_dimension", "length", 30.1)
 
-        assert new_dimension_parm.name == rf'{part.name}\new_dimension'
+        assert new_dimension_parm.name == rf"{part.name}\new_dimension"
         assert new_dimension_parm.value == 30.1
 
 
 def test_create_int():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_int_parm = parameters.create_integer('new_int', 30)
+        new_int_parm = parameters.create_integer("new_int", 30)
 
-        assert new_int_parm.name == rf'{part.name}\new_int'
+        assert new_int_parm.name == rf"{part.name}\new_int"
         assert new_int_parm.value == 30
 
 
 def test_create_list():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_list = parameters.create_list('new_list')
+        new_list = parameters.create_list("new_list")
 
-        assert new_list.name == r'new_list'
+        assert new_list.name == r"new_list"
 
 
 def test_count_parameters():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
@@ -89,19 +89,19 @@ def test_count_parameters():
 
 
 def test_create_real():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_list = parameters.create_real('new_real', 5.4)
+        new_list = parameters.create_real("new_real", 5.4)
 
-        assert new_list.name == rf'{part.name}\new_real'
+        assert new_list.name == rf"{part.name}\new_real"
         assert new_list.value == 5.4
 
 
 def test_create_parameters_set():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
@@ -112,31 +112,31 @@ def test_create_parameters_set():
 
 
 def test_create_string():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_string = parameters.create_string('new_string', "this is a string")
+        new_string = parameters.create_string("new_string", "this is a string")
 
-        assert new_string.name == rf'{part.name}\new_string'
+        assert new_string.name == rf"{part.name}\new_string"
         assert new_string.value == "this is a string"
 
 
 def test_get_name_to_use_in_relation():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        new_string = parameters.create_string('new_string', "this is a string")
+        new_string = parameters.create_string("new_string", "this is a string")
         name_to_use = parameters.get_name_to_use_in_relation(new_string)
 
-        assert name_to_use == 'new_string'
+        assert name_to_use == "new_string"
 
 
 def test_has_parameters():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
@@ -145,14 +145,14 @@ def test_has_parameters():
 
 
 def test_item():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
-        bool_param = parameters.create_boolean('new_boolean', True)
-        int_param = parameters.create_integer('new_integer', 10)
-        str_param = parameters.create_string('new_string', 'new_value')
-        real_param = parameters.create_real('new_real', 10.1)
+        bool_param = parameters.create_boolean("new_boolean", True)
+        int_param = parameters.create_integer("new_integer", 10)
+        str_param = parameters.create_string("new_string", "new_value")
+        real_param = parameters.create_real("new_real", 10.1)
 
         assert type(bool_param) == BoolParam
         assert type(int_param) == IntParam
@@ -165,21 +165,21 @@ def test_sub_list():
         document = caa.document
         part = document.part
         bodies = part.bodies
-        body = Body(bodies.get_item_by_name('PartBody').com_object)
-        shape = Shape(body.shapes.get_item_by_name('Pad.1').com_object)
+        body = Body(bodies.get_item_by_name("PartBody").com_object)
+        shape = Shape(body.shapes.get_item_by_name("Pad.1").com_object)
         parameters = part.parameters
         sub_list = parameters.sub_list(shape, True)
 
-        assert sub_list.item(1).name == r'cat_part_measurable\PartBody\Pad.1\FirstLimit\Length'
+        assert sub_list.item(1).name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
 
 
 def test_remove():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        bool_name = 'new-boolean'
+        bool_name = "new-boolean"
 
         parameters.create_boolean(bool_name, True)
         all_params = parameters.all_parameters

--- a/tests/in/knowledgeware/test_knowledgeware_parameters.py
+++ b/tests/in/knowledgeware/test_knowledgeware_parameters.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from pycatia import CATIADocHandler
 from pycatia.knowledge_interfaces.bool_param import BoolParam

--- a/tests/in/knowledgeware/test_knowledgeware_parameters.py
+++ b/tests/in/knowledgeware/test_knowledgeware_parameters.py
@@ -6,6 +6,7 @@ from pycatia.knowledge_interfaces.int_param import IntParam
 from pycatia.knowledge_interfaces.real_param import RealParam
 from pycatia.knowledge_interfaces.str_param import StrParam
 from pycatia.mec_mod_interfaces.body import Body
+from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.mec_mod_interfaces.shape import Shape
 from tests.source_files import cat_part_measurable
 
@@ -13,7 +14,9 @@ from tests.source_files import cat_part_measurable
 def test_parameters_name():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         first_parameter = parameters.item(1)
@@ -27,7 +30,9 @@ def test_parameters_name():
 def test_all_parameters():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         all_parms = parameters.all_parameters()
@@ -41,7 +46,9 @@ def test_all_parameters():
 def test_create_boolean():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_boolean_parm = parameters.create_boolean("new_boolean", True)
@@ -53,7 +60,9 @@ def test_create_boolean():
 def test_create_dimension():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_dimension_parm = parameters.create_dimension("new_dimension", "length", 30.1)
@@ -65,7 +74,9 @@ def test_create_dimension():
 def test_create_int():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_int_parm = parameters.create_integer("new_int", 30)
@@ -77,7 +88,9 @@ def test_create_int():
 def test_create_list():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_list = parameters.create_list("new_list")
@@ -88,7 +101,9 @@ def test_create_list():
 def test_count_parameters():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         assert parameters.count == 5
@@ -97,7 +112,9 @@ def test_count_parameters():
 def test_create_real():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_list = parameters.create_real("new_real", 5.4)
@@ -109,7 +126,9 @@ def test_create_real():
 def test_create_parameters_set():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
         root_parameter_set = parameters.root_parameter_set
         parameters.create_set_of_parameters(root_parameter_set)
@@ -120,7 +139,9 @@ def test_create_parameters_set():
 def test_create_string():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_string = parameters.create_string("new_string", "this is a string")
@@ -132,7 +153,9 @@ def test_create_string():
 def test_get_name_to_use_in_relation():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         new_string = parameters.create_string("new_string", "this is a string")
@@ -144,7 +167,9 @@ def test_get_name_to_use_in_relation():
 def test_has_parameters():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         assert parameters.has_parameters() > 0
@@ -153,7 +178,9 @@ def test_has_parameters():
 def test_item():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
         bool_param = parameters.create_boolean("new_boolean", True)
         int_param = parameters.create_integer("new_integer", 10)
@@ -169,10 +196,18 @@ def test_item():
 def test_sub_list():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
 
-        body = part.main_body
+        part = PartDocument(document.com_object).part
+
+        body_item = part.main_body
+        assert body_item is not None
+
+        body = Body(body_item.com_object)
         shape_item = body.shapes.get_item_by_name("Pad.1") or body.shapes.get_item_by_name("Block.1")
+
+        assert shape_item is not None
+
         shape = Shape(shape_item.com_object)
         parameters = part.parameters
         sub_list = parameters.sub_list(shape, True)
@@ -185,7 +220,9 @@ def test_sub_list():
 def test_remove():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         bool_name = "new-boolean"

--- a/tests/in/knowledgeware/test_knowledgeware_parameters.py
+++ b/tests/in/knowledgeware/test_knowledgeware_parameters.py
@@ -1,12 +1,12 @@
 #! /usr/bin/python3.6
 
 from pycatia import CATIADocHandler
-from pycatia.mec_mod_interfaces.body import Body
-from pycatia.mec_mod_interfaces.shape import Shape
 from pycatia.knowledge_interfaces.bool_param import BoolParam
 from pycatia.knowledge_interfaces.int_param import IntParam
-from pycatia.knowledge_interfaces.str_param import StrParam
 from pycatia.knowledge_interfaces.real_param import RealParam
+from pycatia.knowledge_interfaces.str_param import StrParam
+from pycatia.mec_mod_interfaces.body import Body
+from pycatia.mec_mod_interfaces.shape import Shape
 from tests.source_files import cat_part_measurable
 
 
@@ -18,7 +18,10 @@ def test_parameters_name():
 
         first_parameter = parameters.item(1)
 
-        assert first_parameter.name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
+        assert first_parameter.name in [
+            r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length",
+            r"cat_part_measurable\Hauptkörper\Block.1\Begrenzung1\Länge",
+        ]
 
 
 def test_all_parameters():
@@ -29,7 +32,10 @@ def test_all_parameters():
 
         all_parms = parameters.all_parameters()
 
-        assert all_parms[0].name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
+        assert all_parms[0].name in [
+            r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length",
+            r"cat_part_measurable\Hauptkörper\Block.1\Begrenzung1\Länge",
+        ]
 
 
 def test_create_boolean():
@@ -108,7 +114,7 @@ def test_create_parameters_set():
         root_parameter_set = parameters.root_parameter_set
         parameters.create_set_of_parameters(root_parameter_set)
         parameter_sets = root_parameter_set.parameter_sets.items()
-        assert parameter_sets[0].__repr__() == 'ParameterSet(name="Parameters.1")'
+        assert parameter_sets[0].__repr__() in ['ParameterSet(name="Parameters.1")', 'ParameterSet(name="Parameter.1")']
 
 
 def test_create_string():
@@ -164,13 +170,16 @@ def test_sub_list():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
         part = document.part
-        bodies = part.bodies
-        body = Body(bodies.get_item_by_name("PartBody").com_object)
-        shape = Shape(body.shapes.get_item_by_name("Pad.1").com_object)
+
+        body = part.main_body
+        shape_item = body.shapes.get_item_by_name("Pad.1") or body.shapes.get_item_by_name("Block.1")
+        shape = Shape(shape_item.com_object)
         parameters = part.parameters
         sub_list = parameters.sub_list(shape, True)
-
-        assert sub_list.item(1).name == r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length"
+        assert sub_list.item(1).name in [
+            r"cat_part_measurable\PartBody\Pad.1\FirstLimit\Length",
+            r"cat_part_measurable\Hauptkörper\Block.1\Begrenzung1\Länge",
+        ]
 
 
 def test_remove():

--- a/tests/in/knowledgeware/test_knowledgeware_relations.py
+++ b/tests/in/knowledgeware/test_knowledgeware_relations.py
@@ -2,15 +2,16 @@
 
 
 from pycatia import CATIADocHandler
-
-from tests.source_files import cat_part_measurable
-from tests.source_files import design_table_1
+from pycatia.mec_mod_interfaces.part_document import PartDocument
+from tests.source_files import cat_part_measurable, design_table_1
 
 
 def test_relations_count():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         assert relations.count == 4
@@ -19,7 +20,9 @@ def test_relations_count():
 def test_relations_create_check():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
 
         lower_mass = parameters.create_dimension("lower_mass", "MASS", 5)
@@ -37,7 +40,9 @@ def test_relations_create_check():
 def test_relations_create_design_table():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         design_table = relations.create_design_table("new-design-table", "this is a comment", True, design_table_1)
@@ -51,7 +56,9 @@ def test_relations_create_formula():
         comment = "this is a comment"
 
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         parameters = part.parameters
 
@@ -73,11 +80,13 @@ def test_relations_create_formula():
 def test_relations_create_horizontal_design_table():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         design_table = relations.create_horizontal_design_table(
-            "new-design-table", "this is a comment", True, design_table_1
+            "new-design-table", "this is a comment", True, str(design_table_1)
         )
 
         assert design_table.name == "new-design-table"
@@ -86,7 +95,9 @@ def test_relations_create_horizontal_design_table():
 def test_relations_create_law():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         law = relations.create_law("new-law", "this is a comment", "/* code comments */")
@@ -97,7 +108,9 @@ def test_relations_create_law():
 def test_relations_create_program():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         program = relations.create_program("new-program", "this is a comment", "/* code comments */")
@@ -108,7 +121,9 @@ def test_relations_create_program():
 def test_relations_create_rule_base():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
 
         rule_base = relations.create_rule_base("new-rule-base")
@@ -119,7 +134,9 @@ def test_relations_create_rule_base():
 def test_relations_create_set_of_equations():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         parameters = part.parameters
         relations = part.relations
 
@@ -135,7 +152,9 @@ def test_relations_create_set_of_equations():
 def test_relations_create_set_of_relations():
     with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         relations = part.relations
         relations.create_set_of_relations(part)
 
@@ -149,7 +168,7 @@ def test_relations_generate_xml():
     # xml_name = Path(os.getcwd(), 'testxml.xml')
     # with CATIADocHandler(cat_part_3) as caa:
     #     document = caa.document
-    #     part = document.part
+    #     part = PartDocument(document.com_object).part
     #
     #     parameters = part.parameters
     #
@@ -170,7 +189,9 @@ def test_relations_generate_xml():
 def test_relations_get_items():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         relations = part.relations
         items = relations.items()
@@ -181,7 +202,9 @@ def test_relations_get_items():
 def test_relations_get_item_by_index():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         relations = part.relations
         item = relations.get_item_by_index(1)
@@ -192,7 +215,9 @@ def test_relations_get_item_by_index():
 def test_relations_get_item_names():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         relations = part.relations
         item_names = relations.get_item_names()
@@ -204,7 +229,9 @@ def test_relations_get_item_names():
 def test_relations_item():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         relations = part.relations
         relation = relations.item(1)
@@ -219,7 +246,9 @@ def test_relations_sub_list():
 def test_relations_remove():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         relations = part.relations
         relation = relations.item(1)

--- a/tests/in/knowledgeware/test_knowledgeware_relations.py
+++ b/tests/in/knowledgeware/test_knowledgeware_relations.py
@@ -1,5 +1,4 @@
-#! /usr/bin/python3.6
-
+#! /usr/bin/python3.9
 
 from pycatia import CATIADocHandler
 from pycatia.mec_mod_interfaces.part_document import PartDocument

--- a/tests/in/knowledgeware/test_knowledgeware_relations.py
+++ b/tests/in/knowledgeware/test_knowledgeware_relations.py
@@ -2,7 +2,8 @@
 
 from pycatia import CATIADocHandler
 from pycatia.mec_mod_interfaces.part_document import PartDocument
-from tests.source_files import cat_part_measurable, design_table_1
+from tests.source_files import cat_part_measurable
+from tests.source_files import design_table_1
 
 
 def test_relations_count():

--- a/tests/in/knowledgeware/test_knowledgeware_relations.py
+++ b/tests/in/knowledgeware/test_knowledgeware_relations.py
@@ -17,41 +17,36 @@ def test_relations_count():
 
 
 def test_relations_create_check():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
 
-        lower_mass = parameters.create_dimension('lower_mass', 'MASS', 5)
+        lower_mass = parameters.create_dimension("lower_mass", "MASS", 5)
         lm_name = parameters.get_name_to_use_in_relation(lower_mass)
 
-        upper_mass = parameters.create_dimension('upper_mass', 'MASS', 10)
+        upper_mass = parameters.create_dimension("upper_mass", "MASS", 10)
         um_name = parameters.get_name_to_use_in_relation(upper_mass)
 
         relations = part.relations
-        new_check = relations.create_check('mass-check', 'this is the comment', f"{lm_name}<{um_name}")
+        new_check = relations.create_check("mass-check", "this is the comment", f"{lm_name}<{um_name}")
 
-        assert new_check.name == 'mass-check'
+        assert new_check.name == "mass-check"
 
 
 def test_relations_create_design_table():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
 
-        design_table = relations.create_design_table(
-            'new-design-table',
-            'this is a comment',
-            True,
-            design_table_1
-        )
+        design_table = relations.create_design_table("new-design-table", "this is a comment", True, design_table_1)
 
-        assert design_table.name == 'new-design-table'
+        assert design_table.name == "new-design-table"
 
 
 def test_relations_create_formula():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         name = "new-formula"
         comment = "this is a comment"
 
@@ -60,68 +55,69 @@ def test_relations_create_formula():
 
         parameters = part.parameters
 
-        lower_mass = parameters.create_dimension('lower_mass', 'MASS', 5)
+        lower_mass = parameters.create_dimension("lower_mass", "MASS", 5)
         lm_name = parameters.get_name_to_use_in_relation(lower_mass)
 
-        upper_mass = parameters.create_dimension('upper_mass', 'MASS', 10)
+        upper_mass = parameters.create_dimension("upper_mass", "MASS", 10)
         um_name = parameters.get_name_to_use_in_relation(upper_mass)
 
-        target_parm = parameters.create_dimension('target_mass', 'MASS', 0)
+        target_parm = parameters.create_dimension("target_mass", "MASS", 0)
 
         relations = part.relations
 
         formula = relations.create_formula(name, comment, target_parm, f"{lm_name}+{um_name}")
 
-        assert formula.name == 'new-formula'
+        assert formula.name == "new-formula"
 
 
 def test_relations_create_horizontal_design_table():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
 
-        design_table = relations.create_horizontal_design_table('new-design-table', 'this is a comment', True,
-                                                                design_table_1)
+        design_table = relations.create_horizontal_design_table(
+            "new-design-table", "this is a comment", True, design_table_1
+        )
 
-        assert design_table.name == 'new-design-table'
+        assert design_table.name == "new-design-table"
 
 
 def test_relations_create_law():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
 
-        law = relations.create_law('new-law', 'this is a comment', '/* code comments */')
+        law = relations.create_law("new-law", "this is a comment", "/* code comments */")
 
-        assert law.name == 'new-law'
+        assert law.name == "new-law"
 
 
 def test_relations_create_program():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
 
-        program = relations.create_program('new-program', 'this is a comment', '/* code comments */')
+        program = relations.create_program("new-program", "this is a comment", "/* code comments */")
 
-        assert program.name == 'new-program'
+        assert program.name == "new-program"
 
 
 def test_relations_create_rule_base():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
 
-        rule_base = relations.create_rule_base('new-rule-base')
+        rule_base = relations.create_rule_base("new-rule-base")
 
-        assert rule_base.name == 'new-rule-base'
+        assert rule_base.name == "new-rule-base"
 
 
 def test_relations_create_set_of_equations():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         parameters = part.parameters
@@ -131,19 +127,19 @@ def test_relations_create_set_of_equations():
         dim_b_name = parameters.get_name_to_use_in_relation(dim_b)
         result = parameters.create_real("result", 0)
 
-        eq_set = relations.create_set_of_equations('new-eq-set', 'some comment', f'{result}=={dim_b_name} + 4;')
+        eq_set = relations.create_set_of_equations("new-eq-set", "some comment", f"{result}=={dim_b_name} + 4;")
 
-        assert eq_set.name == 'new-eq-set'
+        assert eq_set.name == "new-eq-set"
 
 
 def test_relations_create_set_of_relations():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
         part = document.part
         relations = part.relations
         relations.create_set_of_relations(part)
 
-        assert relations.name == 'Relations'
+        assert relations.name == "Relations"
 
 
 def test_relations_generate_xml():
@@ -190,7 +186,7 @@ def test_relations_get_item_by_index():
         relations = part.relations
         item = relations.get_item_by_index(1)
 
-        assert item.name == 'formula_1'
+        assert item.name == "formula_1"
 
 
 def test_relations_get_item_names():
@@ -201,7 +197,7 @@ def test_relations_get_item_names():
         relations = part.relations
         item_names = relations.get_item_names()
 
-        ref_names = ['formula_1', 'formula_2', 'formula_3', 'formula_5']
+        ref_names = ["formula_1", "formula_2", "formula_3", "formula_5"]
         assert item_names == ref_names
 
 
@@ -212,7 +208,7 @@ def test_relations_item():
 
         relations = part.relations
         relation = relations.item(1)
-        assert relation.name == 'formula_1'
+        assert relation.name == "formula_1"
 
 
 def test_relations_sub_list():
@@ -227,8 +223,8 @@ def test_relations_remove():
 
         relations = part.relations
         relation = relations.item(1)
-        assert relation.name == 'formula_1'
+        assert relation.name == "formula_1"
 
         relations.remove(1)
         relation = relations.item(1)
-        assert relation.name != 'formula_1'
+        assert relation.name != "formula_1"

--- a/tests/in/material/test_material.py
+++ b/tests/in/material/test_material.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3.9
+
 import os
 from pathlib import Path
 

--- a/tests/in/material/test_material.py
+++ b/tests/in/material/test_material.py
@@ -6,15 +6,18 @@ from pycatia.cat_mat_interfaces.material_document import MaterialDocument
 from pycatia.cat_mat_interfaces.material_manager import MaterialManager
 from pycatia.mec_mod_interfaces.part import Part
 from pycatia.product_structure_interfaces.product import Product
-from tests.source_files import cat_part_measurable, cat_product, cat_material
 from tests.common_vars import test_files
+from tests.source_files import cat_material, cat_part_measurable, cat_product
 
 icon_folder = Path(os.getcwd(), test_files)
 
 
 def test_material_document():
     with CATIADocHandler(cat_material) as caa:
-        material_document = MaterialDocument(caa.document.com_object)  # type: ignore
+        document = caa.document
+        assert document is not None
+
+        material_document = MaterialDocument(document.com_object)
         material_families = material_document.families
         materials = material_families.item(1).materials
         assert material_families.count > 0
@@ -75,7 +78,10 @@ def test_material_manager_product():
 
 def test_analysis_material():
     with CATIADocHandler(cat_material) as caa:
-        material_document = MaterialDocument(caa.document.com_object)  # type: ignore
+        document = caa.document
+        assert document is not None
+
+        material_document = MaterialDocument(document.com_object)
         material_families = material_document.families
         materials = material_families.item(1).materials
         material = materials.item(1)
@@ -85,12 +91,15 @@ def test_analysis_material():
 
 def test_material():
     with CATIADocHandler(cat_material) as caa:
-        material_document = MaterialDocument(caa.document.com_object)  # type: ignore
+        document = caa.document
+        assert document is not None
+
+        material_document = MaterialDocument(document.com_object)
         material_families = material_document.families
         materials = material_families.item(1).materials
         material = materials.item(1)
-        material.get_icon(icon_folder)  # type: ignore
-        material.put_icon(icon_folder)  # type: ignore
+        material.get_icon(str(icon_folder))
+        material.put_icon(str(icon_folder))
         icon_path = f"{icon_folder}\\{material.name}.jpg"
 
         assert material.exist_analysis_data()

--- a/tests/in/material/test_material.py
+++ b/tests/in/material/test_material.py
@@ -9,7 +9,9 @@ from pycatia.cat_mat_interfaces.material_manager import MaterialManager
 from pycatia.mec_mod_interfaces.part import Part
 from pycatia.product_structure_interfaces.product import Product
 from tests.common_vars import test_files
-from tests.source_files import cat_material, cat_part_measurable, cat_product
+from tests.source_files import cat_material
+from tests.source_files import cat_part_measurable
+from tests.source_files import cat_product
 
 icon_folder = Path(os.getcwd(), test_files)
 

--- a/tests/in/material/test_material.py
+++ b/tests/in/material/test_material.py
@@ -39,23 +39,15 @@ def test_material_manager_part():
 
             material_manager.apply_material_on_body(i_body=main_body, i_material=None)
             material_manager.apply_material_on_part(i_part=part, i_material=None)
-            material_manager.apply_material_on_hybrid_body(
-                i_hybrid_body=hybrid_body, i_material=None
-            )
+            material_manager.apply_material_on_hybrid_body(i_hybrid_body=hybrid_body, i_material=None)
 
-            material_manager.apply_material_on_body(
-                i_body=main_body, i_material=material
-            )
+            material_manager.apply_material_on_body(i_body=main_body, i_material=material)
             material_manager.apply_material_on_part(i_part=part, i_material=material)
-            material_manager.apply_material_on_hybrid_body(
-                i_hybrid_body=hybrid_body, i_material=material
-            )
+            material_manager.apply_material_on_hybrid_body(i_hybrid_body=hybrid_body, i_material=material)
 
             part_mat = material_manager.get_material_on_part(i_part=part)
             body_mat = material_manager.get_material_on_body(i_body=main_body)
-            hybrid_mat = material_manager.get_material_on_hybrid_body(
-                i_hybrid_body=hybrid_body
-            )
+            hybrid_mat = material_manager.get_material_on_hybrid_body(i_hybrid_body=hybrid_body)
 
             assert part_mat.name == material.name
             assert body_mat.name == material.name
@@ -74,12 +66,8 @@ def test_material_manager_product():
             material_item = product.get_item("CATMatManagerVBExt")
             material_manager = MaterialManager(material_item.com_object)
 
-            material_manager.apply_material_on_product(
-                i_product=product, i_material=None
-            )
-            material_manager.apply_material_on_product(
-                i_product=product, i_material=material, i_link_mode=True
-            )
+            material_manager.apply_material_on_product(i_product=product, i_material=None)
+            material_manager.apply_material_on_product(i_product=product, i_material=material, i_link_mode=True)
             product_mat = material_manager.get_material_on_product(i_product=product)
 
             assert product_mat.name == material.name

--- a/tests/in/part/test_part.py
+++ b/tests/in/part/test_part.py
@@ -7,7 +7,8 @@ from pycatia.exception_handling.exceptions import CATIAApplicationException
 from pycatia.mec_mod_interfaces.part import Part
 from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product_document import ProductDocument
-from tests.source_files import cat_part_measurable, cat_product
+from tests.source_files import cat_part_measurable
+from tests.source_files import cat_product
 
 
 def test_activation():

--- a/tests/in/part/test_part.py
+++ b/tests/in/part/test_part.py
@@ -1,4 +1,5 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
+
 import pytest
 
 from pycatia import CATIADocHandler

--- a/tests/in/part/test_part.py
+++ b/tests/in/part/test_part.py
@@ -13,7 +13,7 @@ def test_activation():
     with CATIADocHandler(cat_part_measurable) as caa:
         part = caa.document.part
 
-        item = part.find_object_by_name('Point.1')
+        item = part.find_object_by_name("Point.1")
 
         assert not part.is_inactive(item)
 
@@ -29,7 +29,7 @@ def test_axis_systems():
 
         axis_systems = part.axis_systems
 
-        assert axis_systems.com_object.Item(1).name == 'Axis.1'
+        assert axis_systems.com_object.Item(1).name == "Axis.1"
 
 
 # todo: look into automation this.
@@ -51,7 +51,7 @@ def test_bodies():
 
         bodies = part.bodies
 
-        assert bodies.com_object.Item(1).Name == 'PartBody'
+        assert bodies.com_object.Item(1).Name == "PartBody"
 
 
 def test_create_geometrical_set():
@@ -60,9 +60,9 @@ def test_create_geometrical_set():
         part = document.part
         hybrid_bodies = part.hybrid_bodies
         geometrical_set = hybrid_bodies.add()
-        geometrical_set.name = 'lala'
+        geometrical_set.name = "lala"
 
-        assert geometrical_set.name == 'lala'
+        assert geometrical_set.name == "lala"
 
 
 def test_density_of_part():
@@ -102,17 +102,17 @@ def test_find_object_by_name():
         document = caa.document
         part = document.part
 
-        body = part.find_object_by_name('PartBody')
-        assert body.name == 'PartBody'
+        body = part.find_object_by_name("PartBody")
+        assert body.name == "PartBody"
 
         with pytest.raises(CATIAApplicationException):
-            part.find_object_by_name('lala')
+            part.find_object_by_name("lala")
             pass
 
 
 def test_in_work_object():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_body_name = 'PartBody'
+        part_body_name = "PartBody"
 
         part = caa.document.part
 

--- a/tests/in/part/test_part.py
+++ b/tests/in/part/test_part.py
@@ -2,16 +2,19 @@
 import pytest
 
 from pycatia import CATIADocHandler
-from pycatia.mec_mod_interfaces.part import Part
 from pycatia.exception_handling.exceptions import CATIAApplicationException
-
-from tests.source_files import cat_part_measurable
-from tests.source_files import cat_product
+from pycatia.mec_mod_interfaces.part import Part
+from pycatia.mec_mod_interfaces.part_document import PartDocument
+from pycatia.product_structure_interfaces.product_document import ProductDocument
+from tests.source_files import cat_part_measurable, cat_product
 
 
 def test_activation():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part = caa.document.part
+        document = caa.document
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         item = part.find_object_by_name("Point.1")
 
@@ -25,7 +28,9 @@ def test_activation():
 def test_axis_systems():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         axis_systems = part.axis_systems
 
@@ -47,17 +52,21 @@ def test_axis_systems():
 def test_bodies():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         bodies = part.bodies
 
-        assert bodies.com_object.Item(1).Name == "PartBody"
+        assert bodies.com_object.Item(1).Name in ["PartBody", "Hauptkörper"]
 
 
 def test_create_geometrical_set():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hybrid_bodies = part.hybrid_bodies
         geometrical_set = hybrid_bodies.add()
         geometrical_set.name = "lala"
@@ -68,7 +77,9 @@ def test_create_geometrical_set():
 def test_density_of_part():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         assert part.density == 1000.0
 
@@ -76,7 +87,9 @@ def test_density_of_part():
 def test_file_name():
     with CATIADocHandler(cat_product) as caa:
         document = caa.document
-        product = document.product
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
         products = product.get_products()
 
         for product in products:
@@ -88,7 +101,9 @@ def test_file_name():
 def test_full_name():
     with CATIADocHandler(cat_product) as caa:
         document = caa.document
-        product = document.product
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
         products = product.get_products()
 
         for product in products:
@@ -100,10 +115,13 @@ def test_full_name():
 def test_find_object_by_name():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
 
-        body = part.find_object_by_name("PartBody")
-        assert body.name == "PartBody"
+        part = PartDocument(document.com_object).part
+        part.main_body.name = "test_main_body_name"
+
+        body = part.find_object_by_name("test_main_body_name")
+        assert body.name == "test_main_body_name"
 
         with pytest.raises(CATIAApplicationException):
             part.find_object_by_name("lala")
@@ -112,26 +130,34 @@ def test_find_object_by_name():
 
 def test_in_work_object():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_body_name = "PartBody"
+        document = caa.document
+        assert document is not None
 
-        part = caa.document.part
+        part = PartDocument(document.com_object).part
 
         bodies = part.bodies
-        body = bodies.get_item_by_name(part_body_name)
+        body = bodies.get_item_by_name("PartBody") or bodies.get_item_by_name("Hauptkörper")
 
+        assert body is not None
         part.in_work_object = body
 
-        assert part.in_work_object.name == part_body_name
+        assert part.in_work_object.name in ["PartBody", "Hauptkörper"]
 
 
 def test_is_up_to_date():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part = caa.document.part
+        document = caa.document
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         assert part.is_up_to_date(part)
 
     with CATIADocHandler(new_document="Part") as caa:
-        part = caa.document.part
+        document = caa.document
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
         hsf = part.hybrid_shape_factory
         hbs = part.hybrid_bodies
         hb = hbs.add()
@@ -144,7 +170,9 @@ def test_is_up_to_date():
 def test_path():
     with CATIADocHandler(cat_product) as caa:
         document = caa.document
-        product = document.product
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
         products = product.get_products()
 
         for product in products:
@@ -156,6 +184,8 @@ def test_path():
 def test_repr():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-        part = document.part
+        assert document is not None
+
+        part = PartDocument(document.com_object).part
 
         assert 'Part(name="cat_part_measurable")' == part.__repr__()

--- a/tests/in/product/test_product.py
+++ b/tests/in/product/test_product.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 import os
 from pathlib import Path

--- a/tests/in/product/test_product.py
+++ b/tests/in/product/test_product.py
@@ -5,14 +5,18 @@ from pathlib import Path
 
 from pycatia import CATIADocHandler
 from pycatia.enumeration.enumeration_types import cat_work_mode_type
+from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product import Product
-from tests.source_files import cat_product
-from tests.source_files import cat_part_measurable
+from pycatia.product_structure_interfaces.product_document import ProductDocument
+from tests.source_files import cat_part_measurable, cat_product
 
 
 def test_analyze():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
 
         # assert (
         #         1.0 == product.analyze.mass and
@@ -42,7 +46,10 @@ def test_analyze():
 
 def test_attributes():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
 
         attributes = (
             "(Product) Attributes... \n"
@@ -64,14 +71,19 @@ def test_attributes():
 
 def test_count_children():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
 
+        product = ProductDocument(document.com_object).product
         assert product.count_children() == 4
 
 
 def test_definition():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert "pycatia part for testing" == part_product.definition
 
@@ -82,7 +94,10 @@ def test_definition():
 
 def test_description_instance():
     with CATIADocHandler(cat_product) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
         children = part_product.get_children()
         child = children[0]
 
@@ -96,7 +111,10 @@ def test_description_instance():
 
 def test_description_reference():
     with CATIADocHandler(cat_product) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
         children = part_product.get_children()
         child = children[0]
 
@@ -110,28 +128,40 @@ def test_description_reference():
 
 def test_file_name():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert cat_part_measurable.name == part_product.file_name
 
 
 def test_full_name():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert str(cat_part_measurable) == part_product.full_name
 
 
 def test_get_child():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
         child = product.get_child(0)
         assert child.part_number == "cat_product_sub_1"
 
 
 def test_get_products():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
         products = product.get_products()
 
         assert 'Product(name="cat_product_sub_1.1")' == products[0].__repr__()
@@ -139,33 +169,48 @@ def test_get_products():
 
 def test_has_children():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
 
         assert product.has_children()
 
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert not part_product.has_children()
 
 
 def test_is_catproduct_is_catpart():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
 
         assert product.is_catproduct()
         assert not product.is_catpart()
 
     with CATIADocHandler(cat_part_measurable) as caa:
-        part = caa.document.product
+        document = caa.document
+        assert document is not None
 
-        assert part.is_catpart()
-        assert not part.is_catproduct()
+        part_product = PartDocument(document.com_object).product
+
+        assert part_product.is_catpart()
+        assert not part_product.is_catproduct()
 
 
 def test_move():
     with CATIADocHandler(cat_product) as caa:
-        product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        product = ProductDocument(document.com_object).product
 
         product.apply_work_mode(cat_work_mode_type.index("DESIGN_MODE"))
 
@@ -192,14 +237,19 @@ def test_move():
 
 def test_name():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
 
+        part_product = PartDocument(document.com_object).product
         assert "cat_part_measurable" == part_product.name
 
 
 def test_nomenclature():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert "pycatia part for testing" == part_product.nomenclature
 
@@ -212,7 +262,10 @@ def test_nomenclature():
 
 def test_part_number():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert "cat_part_measurable" == part_product.part_number
 
@@ -223,7 +276,10 @@ def test_part_number():
 
 def test_path():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         product_path = Path(os.getcwd(), cat_part_measurable)
 
@@ -247,7 +303,10 @@ def test_publications():
 
 def test_reference_product():
     with CATIADocHandler(cat_product) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert part_product.reference_product.name == "cat_product_1"
 
@@ -259,7 +318,10 @@ def test_relations():
 
 def test_revision():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part_product = caa.document.product
+        document = caa.document
+        assert document is not None
+
+        part_product = PartDocument(document.com_object).product
 
         assert "A.1" == part_product.revision
 
@@ -385,6 +447,9 @@ def test_update():
 
 def test_repr():
     with CATIADocHandler(cat_part_measurable) as caa:
-        part = caa.document.product
+        document = caa.document
+        assert document is not None
 
-        assert 'Product(name="cat_part_measurable")' == part.__repr__()
+        part_product = PartDocument(document.com_object).product
+
+        assert 'Product(name="cat_part_measurable")' == part_product.__repr__()

--- a/tests/in/product/test_product.py
+++ b/tests/in/product/test_product.py
@@ -27,27 +27,37 @@ def test_analyze():
         assert 1500000.0 == product.analyze.volume
         assert 120000.0 == product.analyze.wet_area
         assert (50.0, 50.0, 25.0) == product.analyze.get_gravity_center()
-        assert (1562.5000000000005, 0.0, 0.0,
-                0.0, 1562.5000000000005, 0.0,
-                0.0, 0.0, 2499.9999999999986) == product.analyze.get_inertia()
+        assert (
+            1562.5000000000005,
+            0.0,
+            0.0,
+            0.0,
+            1562.5000000000005,
+            0.0,
+            0.0,
+            0.0,
+            2499.9999999999986,
+        ) == product.analyze.get_inertia()
 
 
 def test_attributes():
     with CATIADocHandler(cat_product) as caa:
         product = caa.document.product
 
-        attributes = ('(Product) Attributes... \n'
-                      'File Name:             product_top.CATProduct\n'
-                      'Name:                  cat_product_1\n'
-                      'Part Number:           cat_product_1\n'
-                      'Revision:              A.1\n'
-                      'Definition:            pycatia product for testing\n'
-                      'Nomenclature:          pycatia product for testing\n'
-                      'Description Instance:  \n'
-                      'Description Reference: \n'
-                      'Reference:             Product(name="cat_product_1")\n'
-                      'Is CATProduct:         True\n'
-                      'Is CATPart:            False')
+        attributes = (
+            "(Product) Attributes... \n"
+            "File Name:             product_top.CATProduct\n"
+            "Name:                  cat_product_1\n"
+            "Part Number:           cat_product_1\n"
+            "Revision:              A.1\n"
+            "Definition:            pycatia product for testing\n"
+            "Nomenclature:          pycatia product for testing\n"
+            "Description Instance:  \n"
+            "Description Reference: \n"
+            'Reference:             Product(name="cat_product_1")\n'
+            "Is CATProduct:         True\n"
+            "Is CATPart:            False"
+        )
 
         assert product.attributes() == attributes
 
@@ -63,11 +73,11 @@ def test_definition():
     with CATIADocHandler(cat_part_measurable) as caa:
         part_product = caa.document.product
 
-        assert 'pycatia part for testing' == part_product.definition
+        assert "pycatia part for testing" == part_product.definition
 
-        part_product.definition = 'new definition'
+        part_product.definition = "new definition"
 
-        assert 'new definition' == part_product.definition
+        assert "new definition" == part_product.definition
 
 
 def test_description_instance():
@@ -76,9 +86,9 @@ def test_description_instance():
         children = part_product.get_children()
         child = children[0]
 
-        assert 'description instance text' == child.description_instance
+        assert "description instance text" == child.description_instance
 
-        new_instance_name = 'description instance text.1'
+        new_instance_name = "description instance text.1"
         child.description_instance = new_instance_name
 
         assert new_instance_name == child.description_instance
@@ -90,9 +100,9 @@ def test_description_reference():
         children = part_product.get_children()
         child = children[0]
 
-        assert '' == child.description_reference
+        assert "" == child.description_reference
 
-        new_description_reference = 'This is the definition for CF_SubProduct1 2'
+        new_description_reference = "This is the definition for CF_SubProduct1 2"
         child.description_reference = new_description_reference
 
         assert new_description_reference == child.description_reference
@@ -116,7 +126,7 @@ def test_get_child():
     with CATIADocHandler(cat_product) as caa:
         product = caa.document.product
         child = product.get_child(0)
-        assert child.part_number == 'cat_product_sub_1'
+        assert child.part_number == "cat_product_sub_1"
 
 
 def test_get_products():
@@ -159,20 +169,7 @@ def test_move():
 
         product.apply_work_mode(cat_work_mode_type.index("DESIGN_MODE"))
 
-        transformation = (
-            1.000,
-            0,
-            0,
-            0,
-            0.707,
-            0.707,
-            0,
-            -0.707,
-            0.707,
-            10.000,
-            20.000,
-            30.000
-        )
+        transformation = (1.000, 0, 0, 0, 0.707, 0.707, 0, -0.707, 0.707, 10.000, 20.000, 30.000)
 
         Product.activate_terminal_node(product.get_products())
         # move the first child in parent.
@@ -180,25 +177,33 @@ def test_move():
 
         product.move.apply(transformation)
 
-        assert ((520.8333333333333, 0.0, 0.0,
-                 0.0, 677.0833333333264, -156.24999999999818,
-                 0.0, -156.24999999999818, 677.0833333333264) == product.analyze.get_inertia())
+        assert (
+            520.8333333333333,
+            0.0,
+            0.0,
+            0.0,
+            677.0833333333264,
+            -156.24999999999818,
+            0.0,
+            -156.24999999999818,
+            677.0833333333264,
+        ) == product.analyze.get_inertia()
 
 
 def test_name():
     with CATIADocHandler(cat_part_measurable) as caa:
         part_product = caa.document.product
 
-        assert 'cat_part_measurable' == part_product.name
+        assert "cat_part_measurable" == part_product.name
 
 
 def test_nomenclature():
     with CATIADocHandler(cat_part_measurable) as caa:
         part_product = caa.document.product
 
-        assert 'pycatia part for testing' == part_product.nomenclature
+        assert "pycatia part for testing" == part_product.nomenclature
 
-        new_nomenclature = 'New Test Part'
+        new_nomenclature = "New Test Part"
 
         part_product.nomenclature = new_nomenclature
 
@@ -209,11 +214,11 @@ def test_part_number():
     with CATIADocHandler(cat_part_measurable) as caa:
         part_product = caa.document.product
 
-        assert 'cat_part_measurable' == part_product.part_number
+        assert "cat_part_measurable" == part_product.part_number
 
-        part_product.part_number = 'new_part_number'
+        part_product.part_number = "new_part_number"
 
-        assert 'new_part_number' == part_product.part_number
+        assert "new_part_number" == part_product.part_number
 
 
 def test_path():
@@ -244,7 +249,7 @@ def test_reference_product():
     with CATIADocHandler(cat_product) as caa:
         part_product = caa.document.product
 
-        assert part_product.reference_product.name == 'cat_product_1'
+        assert part_product.reference_product.name == "cat_product_1"
 
 
 def test_relations():
@@ -256,11 +261,11 @@ def test_revision():
     with CATIADocHandler(cat_part_measurable) as caa:
         part_product = caa.document.product
 
-        assert 'A.1' == part_product.revision
+        assert "A.1" == part_product.revision
 
-        part_product.revision = 'B'
+        part_product.revision = "B"
 
-        assert 'B' == part_product.revision
+        assert "B" == part_product.revision
 
 
 def test_activate_default_shape():

--- a/tests/in/product/test_product.py
+++ b/tests/in/product/test_product.py
@@ -8,7 +8,8 @@ from pycatia.enumeration.enumeration_types import cat_work_mode_type
 from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product import Product
 from pycatia.product_structure_interfaces.product_document import ProductDocument
-from tests.source_files import cat_part_measurable, cat_product
+from tests.source_files import cat_part_measurable
+from tests.source_files import cat_product
 
 
 def test_analyze():

--- a/tests/in/test_application.py
+++ b/tests/in/test_application.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from tests.common_vars import caa
 from tests.source_files import cat_part_measurable

--- a/tests/in/test_application.py
+++ b/tests/in/test_application.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python3.6
 
-from tests.source_files import cat_part_measurable
 from tests.common_vars import caa
+from tests.source_files import cat_part_measurable
 
 
 def test_application():
@@ -10,7 +10,7 @@ def test_application():
 
 def test_refresh():
     documents = caa.documents
-    documents.open(cat_part_measurable)
+    documents.open(str(cat_part_measurable))
     document = caa.active_document
 
     caa.refresh_display = False
@@ -24,7 +24,7 @@ def test_refresh():
 
 def test_visible():
     documents = caa.documents
-    documents.open(cat_part_measurable)
+    documents.open(str(cat_part_measurable))
     document = caa.active_document
 
     caa.visible = False

--- a/tests/in/test_document.py
+++ b/tests/in/test_document.py
@@ -10,7 +10,7 @@ from tests.common_vars import caa
 from tests.source_files import cat_part_measurable
 from tests.source_files import cat_product
 
-now_string = datetime.now().strftime('%Y%m%d-%H%M%S')
+now_string = datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
 def test_activate_document():
@@ -33,17 +33,17 @@ def test_activate_document():
 
 
 def test_add_documents():
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        assert 'CATPart' in document.name
+        assert "CATPart" in document.name
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        assert 'CATPart' in document.name
+        assert "CATPart" in document.name
 
-    with CATIADocHandler(new_document='Part') as caa:
+    with CATIADocHandler(new_document="Part") as caa:
         document = caa.document
-        assert 'CATPart' in document.name
+        assert "CATPart" in document.name
 
     # commented out due to failing tests and I can't remember why this was added
     # in the first place ...
@@ -56,7 +56,7 @@ def test_count_types():
     with CATIADocHandler(cat_product) as caa:
         documents = caa.documents
 
-        num = documents.count_types('.catpart')
+        num = documents.count_types(".catpart")
 
         assert num == 1
 
@@ -65,17 +65,17 @@ def test_export_document():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
 
-        export_type = 'igs'
-        export_name = 'export_file'
+        export_type = "igs"
+        export_name = "export_file"
 
         path = os.path.dirname(os.path.abspath(cat_part_measurable))
         export_name = os.path.join(path, export_name)
 
         document.export_data(f"{export_name}.{export_type}", export_type)
 
-        assert os.path.isfile(f'{export_name}.igs')
+        assert os.path.isfile(f"{export_name}.igs")
 
-        os.remove(f'{export_name}.igs')
+        os.remove(f"{export_name}.igs")
 
 
 def test_full_name():
@@ -93,10 +93,10 @@ def test_get_documents_names():
         documents = caa.documents
 
         expected_names = [
-            'product_top.CATProduct',
-            'product_sub_2.CATProduct',
-            'part_measurable.CATPart',
-            'product_sub_1.CATProduct',
+            "product_top.CATProduct",
+            "product_sub_2.CATProduct",
+            "part_measurable.CATPart",
+            "product_sub_1.CATProduct",
         ]
 
         assert documents.get_item_names() == expected_names
@@ -111,7 +111,7 @@ def test_is_saved():
 
         # create a new geometrical set to add point.
         geometrical_set = part.hybrid_bodies.add()
-        geometrical_set.Name = 'lalalalalala'
+        geometrical_set.Name = "lalalalalala"
 
         # just adding geometrical set isn't enough to trigger is_saved to be False
         # catia r21 bug?
@@ -129,7 +129,7 @@ def test_item():
         documents = caa.documents
         doc_com1 = documents.item(cat_product.name)
 
-        assert (doc_com1.name == cat_product.name)
+        assert doc_com1.name == cat_product.name
 
 
 def test_new_from():
@@ -141,13 +141,13 @@ def test_new_from():
     document.close()
 
     with pytest.raises(FileNotFoundError):
-        documents.new_from('lala')
+        documents.new_from("lala")
 
 
 def test_no_such_file():
     with pytest.raises(FileNotFoundError):
         documents = caa.documents
-        documents.open('lala')
+        documents.open("lala")
 
 
 def test_num_open():
@@ -182,12 +182,12 @@ def test_product():
     with CATIADocHandler(cat_product) as caa:
         document = caa.document
         product = document.product
-        assert 'cat_product_1' in product.name
+        assert "cat_product_1" in product.name
         assert document.is_product
 
 
 def test_saving():
-    new_filename = os.path.join(os.getcwd(), '__junk__/', (now_string + '.CATPart'))
+    new_filename = os.path.join(os.getcwd(), "__junk__/", (now_string + ".CATPart"))
 
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document

--- a/tests/in/test_document.py
+++ b/tests/in/test_document.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 import os
 from datetime import datetime

--- a/tests/in/test_document.py
+++ b/tests/in/test_document.py
@@ -1,16 +1,17 @@
 #! /usr/bin/python3.6
 
-from datetime import datetime
 import os
+from datetime import datetime
 
 import pytest
 
 from pycatia.base_interfaces.context import CATIADocHandler
 from tests.common_vars import caa
-from tests.source_files import cat_part_measurable
-from tests.source_files import cat_product
+from tests.source_files import cat_part_measurable, cat_product
 
+junk_folder = os.path.join(os.getcwd(), "__junk__/")
 now_string = datetime.now().strftime("%Y%m%d-%H%M%S")
+os.makedirs(junk_folder, exist_ok=True)
 
 
 def test_activate_document():
@@ -187,7 +188,7 @@ def test_product():
 
 
 def test_saving():
-    new_filename = os.path.join(os.getcwd(), "__junk__/", (now_string + ".CATPart"))
+    new_filename = os.path.join(junk_folder, (now_string + ".CATPart"))
 
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document

--- a/tests/in/test_document.py
+++ b/tests/in/test_document.py
@@ -10,7 +10,8 @@ from pycatia.base_interfaces.context import CATIADocHandler
 from pycatia.mec_mod_interfaces.part_document import PartDocument
 from pycatia.product_structure_interfaces.product_document import ProductDocument
 from tests.common_vars import caa
-from tests.source_files import cat_part_measurable, cat_product
+from tests.source_files import cat_part_measurable
+from tests.source_files import cat_product
 
 junk_folder = os.path.join(os.getcwd(), "__junk__/")
 now_string = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tests/in/test_measurable.py
+++ b/tests/in/test_measurable.py
@@ -9,14 +9,12 @@ from pycatia import CATIADocHandler
 from pycatia.enumeration.enumeration_types import cat_measurable_name
 from pycatia.mec_mod_interfaces.hybrid_body import HybridBody
 from pycatia.mec_mod_interfaces.part_document import PartDocument
-from tests.create_source_parts import (
-    geom_set_arcs,
-    geom_set_cylinders,
-    geom_set_lines,
-    geom_set_planes,
-    geom_set_points,
-    geom_set_surfaces,
-)
+from tests.create_source_parts import geom_set_arcs
+from tests.create_source_parts import geom_set_cylinders
+from tests.create_source_parts import geom_set_lines
+from tests.create_source_parts import geom_set_planes
+from tests.create_source_parts import geom_set_points
+from tests.create_source_parts import geom_set_surfaces
 from tests.source_files import cat_part_measurable
 
 

--- a/tests/in/test_measurable.py
+++ b/tests/in/test_measurable.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 """
     This file is named test_measurable.py so these tests are run first. Otherwise the tests would fail for

--- a/tests/in/test_measurable.py
+++ b/tests/in/test_measurable.py
@@ -1,19 +1,23 @@
 #! /usr/bin/python3.6
 
 """
-    This file is named test_measurable.py so these tests are run first. Othwerise the tests would fail for
+    This file is named test_measurable.py so these tests are run first. Otherwise the tests would fail for
     test_document.py. I've no idea why at the moment.
 """
 
 from pycatia import CATIADocHandler
 from pycatia.enumeration.enumeration_types import cat_measurable_name
+from pycatia.mec_mod_interfaces.hybrid_body import HybridBody
+from pycatia.mec_mod_interfaces.part_document import PartDocument
+from tests.create_source_parts import (
+    geom_set_arcs,
+    geom_set_cylinders,
+    geom_set_lines,
+    geom_set_planes,
+    geom_set_points,
+    geom_set_surfaces,
+)
 from tests.source_files import cat_part_measurable
-from tests.create_source_parts import geom_set_lines
-from tests.create_source_parts import geom_set_surfaces
-from tests.create_source_parts import geom_set_arcs
-from tests.create_source_parts import geom_set_points
-from tests.create_source_parts import geom_set_planes
-from tests.create_source_parts import geom_set_cylinders
 
 
 def round_tuple(tuple_object, decimal_places=6):
@@ -32,9 +36,10 @@ def round_tuple(tuple_object, decimal_places=6):
 def test_area():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
 
-        part = document.part
+        part = PartDocument(document.com_object).part
         bodies = part.bodies
         body = bodies.item(1)
 
@@ -50,9 +55,10 @@ def test_area():
 def test_geometry_name():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
 
-        part = document.part
+        part = PartDocument(document.com_object).part
         bodies = part.bodies
         body = bodies.item(1)
 
@@ -65,11 +71,15 @@ def test_geometry_name():
 def test_length():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
 
-        part = document.part
+        part = PartDocument(document.com_object).part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_lines)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_lines)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         line1 = hybrid_body.hybrid_shapes.item(1)
         line1_reference = part.create_reference_from_object(line1)
         line1_measurable = spa_workbench.get_measurable(line1_reference)
@@ -83,10 +93,15 @@ def test_length():
 def test_perimeter():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
-        part = document.part
+        part = PartDocument(document.com_object).part
+
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_surfaces)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_surfaces)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         surface = hybrid_body.hybrid_shapes.item(1)
         surface_reference = part.create_reference_from_object(surface)
         surface_measurable = spa_workbench.get_measurable(surface_reference)
@@ -100,11 +115,15 @@ def test_perimeter():
 def test_radius():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         arc = hybrid_body.hybrid_shapes.item(1)
         arc_reference = part.create_reference_from_object(arc)
         arc_measurable = spa_workbench.get_measurable(arc_reference)
@@ -117,11 +136,15 @@ def test_radius():
 def test_angle_between():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_lines)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_lines)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         line1 = hybrid_body.hybrid_shapes.item(1)
         line1_reference = part.create_reference_from_object(line1)
         line1_measurable = spa_workbench.get_measurable(line1_reference)
@@ -142,11 +165,15 @@ def test_get_axis():
 
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         arc = hybrid_body.hybrid_shapes.item(1)
         arc_reference = part.create_reference_from_object(arc)
         arc_measurable = spa_workbench.get_measurable(arc_reference)
@@ -163,9 +190,9 @@ def test_get_axis_system():
     """
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
-        part = document.part
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
         axis_systems = part.axis_systems
         axis = axis_systems.item(1)
@@ -194,11 +221,15 @@ def test_get_axis_system():
 def test_get_direction():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
-        part = document.part
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
+
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_lines)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_lines)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         line1 = hybrid_body.hybrid_shapes.item(1)
         line1_reference = part.create_reference_from_object(line1)
         line1_measurable = spa_workbench.get_measurable(line1_reference)
@@ -216,17 +247,23 @@ def test_get_direction():
 def test_get_minimum_distance():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
-        part = document.part
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_lines)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_lines)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         line1 = hybrid_body.hybrid_shapes.item(1)
         line1_reference = part.create_reference_from_object(line1)
         line1_measurable = spa_workbench.get_measurable(line1_reference)
 
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_points)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_points)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         point = hybrid_body.hybrid_shapes.item(2)
         point_reference = part.create_reference_from_object(point)
 
@@ -239,11 +276,16 @@ def test_get_minimum_distance():
 def test_get_minimum_distance_points():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
-        part = document.part
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
+
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_points)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_points)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
+
         point1 = hybrid_body.hybrid_shapes.item(1)
         point1_reference = part.create_reference_from_object(point1)
         point1_measurable = spa_workbench.get_measurable(point1_reference)
@@ -260,11 +302,15 @@ def test_get_minimum_distance_points():
 def test_get_plane():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
+        assert document is not None
         spa_workbench = document.spa_workbench()
-        part = document.part
+        part = PartDocument(document.com_object).part
+
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_planes)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_planes)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         plane = hybrid_body.hybrid_shapes.item(1)
         plane_reference = part.create_reference_from_object(plane)
         plane_measurable = spa_workbench.get_measurable(plane_reference)
@@ -279,11 +325,15 @@ def test_get_plane():
 def test_get_point():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_points)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_points)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         point1 = hybrid_body.hybrid_shapes.item(3)
         point1_reference = part.create_reference_from_object(point1)
         point1_measurable = spa_workbench.get_measurable(point1_reference)
@@ -302,11 +352,15 @@ def test_get_point():
 def test_get_points_on_axis():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_cylinders)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_cylinders)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         cylinder = hybrid_body.hybrid_shapes.item(1)
         cylinder_reference = part.create_reference_from_object(cylinder)
         cylinder_measurable = spa_workbench.get_measurable(cylinder_reference)
@@ -331,11 +385,15 @@ def test_get_points_on_axis():
 def test_get_points_on_curve():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_lines)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_lines)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         line1 = hybrid_body.hybrid_shapes.item(1)
         line1_reference = part.create_reference_from_object(line1)
         line1_measurable = spa_workbench.get_measurable(line1_reference)
@@ -360,9 +418,10 @@ def test_get_points_on_curve():
 def test_volume():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         bodies = part.bodies
         body = bodies.item(1)
 
@@ -378,9 +437,10 @@ def test_volume():
 def test_centre_of_gravity():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         bodies = part.bodies
         body = bodies.item(1)
 
@@ -403,11 +463,15 @@ def test_centre_of_gravity():
 def test_angle():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
+        assert document is not None
         spa_workbench = document.spa_workbench()
+        part = PartDocument(document.com_object).part
 
-        part = document.part
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         arc = hybrid_body.hybrid_shapes.item(1)
         arc_reference = part.create_reference_from_object(arc)
         arc_measurable = spa_workbench.get_measurable(arc_reference)
@@ -421,11 +485,15 @@ def test_angle():
 def test_center():
     with CATIADocHandler(cat_part_measurable) as caa:
         document = caa.document
-
+        assert document is not None
         spa_workbench = document.spa_workbench()
-        part = document.part
+        part = PartDocument(document.com_object).part
+
         hybrid_bodies = part.hybrid_bodies
-        hybrid_body = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        hybrid_body_item = hybrid_bodies.get_item_by_name(geom_set_arcs)
+        assert hybrid_body_item is not None
+
+        hybrid_body = HybridBody(hybrid_body_item.com_object)
         arc = hybrid_body.hybrid_shapes.item(1)
 
         arc_reference = part.create_reference_from_object(arc)

--- a/tests/in/test_measurable.py
+++ b/tests/in/test_measurable.py
@@ -59,7 +59,7 @@ def test_geometry_name():
         reference = part.create_reference_from_object(body)
         measurable = spa_workbench.get_measurable(reference)
 
-        assert measurable.geometry_name == cat_measurable_name.index('CatMeasurableVolume')
+        assert measurable.geometry_name == cat_measurable_name.index("CatMeasurableVolume")
 
 
 def test_length():
@@ -172,19 +172,7 @@ def test_get_axis_system():
         axis_reference = part.create_reference_from_object(axis)
         axis_measurable = spa_workbench.get_measurable(axis_reference)
 
-        axis_system = (
-            0.000,
-            0.000,
-            0.000,
-            1.000,
-            0.000,
-            0.000,
-            0.000,
-            1.000,
-            0.000000,
-            0.000000,
-            0.000000,
-            1.000000)
+        axis_system = (0.000, 0.000, 0.000, 1.000, 0.000, 0.000, 0.000, 1.000, 0.000000, 0.000000, 0.000000, 1.000000)
         catia_axis = axis_measurable.get_axis_system()
 
         assert axis_system == (
@@ -263,17 +251,7 @@ def test_get_minimum_distance_points():
         point2 = hybrid_body.hybrid_shapes.item(3)
         point2_reference = part.create_reference_from_object(point2)
 
-        minimum_distance_points = (
-            0.000000,
-            0.000000,
-            0.000000,
-            100.000000,
-            100.000000,
-            0.000000,
-            None,
-            None,
-            None
-        )
+        minimum_distance_points = (0.000000, 0.000000, 0.000000, 100.000000, 100.000000, 0.000000, None, None, None)
         catia_minimum_distance_points = point1_measurable.get_minimum_distance_points(point2_reference)
 
         assert minimum_distance_points == round_tuple(catia_minimum_distance_points, 6)
@@ -291,17 +269,7 @@ def test_get_plane():
         plane_reference = part.create_reference_from_object(plane)
         plane_measurable = spa_workbench.get_measurable(plane_reference)
 
-        plane = (
-            0.0,
-            0.0,
-            -200.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0
-        )
+        plane = (0.0, 0.0, -200.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         catia_plane = plane_measurable.get_plane()
         catia_plane = round_tuple(catia_plane, 6)
 
@@ -428,7 +396,8 @@ def test_centre_of_gravity():
         assert (gx, gy, gz) == (
             round(centre_of_gravity[0], 6),
             round(centre_of_gravity[1], 6),
-            round(centre_of_gravity[2], 6))
+            round(centre_of_gravity[2], 6),
+        )
 
 
 def test_angle():

--- a/tests/in/test_unit_convertions.py
+++ b/tests/in/test_unit_convertions.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.6
+#! /usr/bin/python3.9
 
 from pycatia.scripts.csv_tools import unit_conversion
 

--- a/tests/in/test_unit_convertions.py
+++ b/tests/in/test_unit_convertions.py
@@ -6,11 +6,12 @@ from pycatia.scripts.csv_tools import unit_conversion
 def test_units():
     input_unit = 5
 
-    assert input_unit == (input_unit * unit_conversion['mm'])
-    assert 50 == (input_unit * unit_conversion['cm'])
-    assert 5000 == (input_unit * unit_conversion['m'])
-    assert 5e+6 == (input_unit * unit_conversion['km'])
-    assert 127 == (input_unit * unit_conversion['in'])
-    assert 8046720 == (input_unit * unit_conversion['mile'])
+    assert input_unit == (input_unit * unit_conversion["mm"])
+    assert 50 == (input_unit * unit_conversion["cm"])
+    assert 5000 == (input_unit * unit_conversion["m"])
+    assert 5e6 == (input_unit * unit_conversion["km"])
+    assert 127 == (input_unit * unit_conversion["in"])
+    assert 8046720 == (input_unit * unit_conversion["mile"])
+
 
 # todo: add test for convert_units function.

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -11,6 +11,6 @@ def initialise():
     """
     documents = catia.documents
     if documents.count > 0:
-        raise CATIAApplicationException('Please close all documents before running tests.')
+        raise CATIAApplicationException("Please close all documents before running tests.")
 
     return catia, documents


### PR DESCRIPTION
I updated the tests:

- Fixed all type errors (so my linter's happy)
- Added german language where it's needed (maybe I add other languages in the future)
- Auto-formatted all tests using black 22.10.0 (I hope that doesn't bother you, if no, would you mind adding black to the dev-requirements?)

The following tests won't pass:

- `test_document.test_get_documents_names`: Expected names don't match the return value
- `test_document.test_num_open`: Number of open docs is zero.
- `test_part.test_activation`: Returns com-error -2147352567, I don't know why
- `test_knowledgeware_relations.test_relations_create_check`: Don't have the required license for that.
- `test_knowledgeware_relations.test_relations_create_program`: Don't have the required license for that.
- `test_knowledgeware_relations.test_relations_create_set_of_equations`: Don't have the required license for that.
- `test_knowledgeware_relations.test_relations_create_set_of_relations`: Don't have the required license for that.
- `test_functional_document.test_current_description`: Doc can't be read, maybe wrong CATIA version (B27)
- `test_functional_document.test_original_description`: Doc can't be read, maybe wrong CATIA version (B27)
