### PR TITLE
examples/assembly-convertor

### DIFF
--- a/examples/example__assembly_convertor__001.py
+++ b/examples/example__assembly_convertor__001.py
@@ -2,7 +2,7 @@
 
 """
 
-    Example - Asssembly Convetor - 001
+    Example - Assembly Convertor - 001
 
     Print the BOM of a product to XLS using the inbuilt AssemblyConvertor. You
     must already have excel installed.
@@ -23,13 +23,13 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('..\\pycatia'))
+sys.path.insert(0, os.path.abspath("..\\pycatia"))
 ##########################################################
 from pathlib import Path
 
 from pycatia import catia
-from pycatia.product_structure_interfaces.product import Product
 from pycatia.product_structure_interfaces.assembly_convertor import AssemblyConvertor
+from pycatia.product_structure_interfaces.product import Product
 
 # file_type can be "TXT", "HTML" or "XLS".
 file_type = "XLS"
@@ -68,5 +68,3 @@ assembly_convertor.set_current_format(details_top)
 assembly_convertor.set_secondary_format(details_recap)
 
 assembly_convertor.print(file_type, excel_file, product)
-
-

--- a/examples/example__assembly_convertor__001.py
+++ b/examples/example__assembly_convertor__001.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from pycatia import catia
 from pycatia.product_structure_interfaces.assembly_convertor import AssemblyConvertor
 from pycatia.product_structure_interfaces.product import Product
+from pycatia.product_structure_interfaces.product_document import ProductDocument
 
 # file_type can be "TXT", "HTML" or "XLS".
 file_type = "XLS"
@@ -55,7 +56,7 @@ if excel_file.is_file():
 
 caa = catia()
 document = caa.active_document
-product = document.product
+product = ProductDocument(document.com_object).product
 # not neccessary but will provide autocompletion in IDEs.
 product = Product(product.com_object)
 

--- a/examples/example__assembly_convertor__001.py
+++ b/examples/example__assembly_convertor__001.py
@@ -69,3 +69,13 @@ assembly_convertor.set_current_format(details_top)
 assembly_convertor.set_secondary_format(details_recap)
 
 assembly_convertor.print(file_type, excel_file, product)
+# Important note:
+# The print-method will fail if you try to export the bill-of-material-xls file
+# to a location, where another process will access this file. Such process is
+# for example OneDrive or Dropbox.
+# One solution to avoid this problem is to export the bom to the current users
+# temp folder and then move it to the desired destination using shutil.move(),
+# see https://docs.python.org/3/library/shutil.html#shutil.move
+# To this particular problem:
+# Once the print-method had failed, it will continue to fail until you restart
+# CATIA, even if you've changed the path to a 'save' location.


### PR DESCRIPTION
The problem:
The print-method will fail if you try to export the bill-of-material-xls file to a location, where another process will access this file. Such process is for example OneDrive.

Added a note at the bottom of the *example__assembly_convertor__001.py* file about when the print method will fail. I tested this on two different machines (Win10 & Win11) using CATIA V5-6R 2017. Please test it yourself to check if the problem is consistent.

The error output looks like this:
```bash
pywintypes.com_error: (-2147352567, 'Exception occurred.', (0, None, 'ExecuteScript(Evaluate, MemoryMacro, print)\nAusführungsfehler\n(Die Scriptmaschine für CATScript hat den folgenden Fehler gemeldet:\n\nQuelle: CATIAAssemblyConvertor\nBeschreibung: Das Verfahren Print ist fehlgeschlagen\nLinie:3\nSpalte: 12\n)\n', None, 0, -2147467259), None)
```

As stated in the comment: this error is persistent until you resart CATIA, even if you print the bom to a save location.
Quick note to this: When you changed the location (temp-dir, etc.) without a restart, the exported bom will be okay and complete, but the error still shows up.