### PR TITLE
fix hybrid_shape_plane_angle.py

### DIFF
--- a/pycatia/hybrid_shape_interfaces/hybrid_shape_plane_angle.py
+++ b/pycatia/hybrid_shape_interfaces/hybrid_shape_plane_angle.py
@@ -97,7 +97,7 @@ class HybridShapePlaneAngle(Plane):
         self.hybrid_shape_plane_angle.Orientation = value
 
     @property
-    def plane(self) -> Reference:
+    def ref_plane(self) -> Reference:
         """
         .. note::
             :class: toggle
@@ -114,8 +114,8 @@ class HybridShapePlaneAngle(Plane):
 
         return Reference(self.hybrid_shape_plane_angle.Plane)
 
-    @plane.setter
-    def plane(self, reference_plane: Reference):
+    @ref_plane.setter
+    def ref_plane(self, reference_plane: Reference):
         """
         :param Reference reference_plane:
         """


### PR DESCRIPTION
Fix for setting reference plane to an angle plane. Just "plane" raises AttributeError: AddNewPlaneAngle.com_object.