### PR TITLE
Update parameters.py

### DIFF
--- a/pycatia/knowledge_interfaces/parameters.py
+++ b/pycatia/knowledge_interfaces/parameters.py
@@ -429,21 +429,25 @@ class Parameters(Collection):
         if not self.is_parameter(index):
             raise CATIAApplicationException(f'Could not find parameter name "{index}".')
 
-        if isinstance(self.parameters.Item(index).value, bool):
-            p = BoolParam(self.parameters.Item(index))
+        if not self.is_list_parameter(index):
 
-        elif isinstance(self.parameters.Item(index).value, int):
-            p = IntParam(self.parameters.Item(index))
+            if isinstance(self.parameters.Item(index).value, bool):
+                p = BoolParam(self.parameters.Item(index))
 
-        elif isinstance(self.parameters.Item(index).value, str):
-            p = StrParam(self.parameters.Item(index))
+            elif isinstance(self.parameters.Item(index).value, int):
+                p = IntParam(self.parameters.Item(index))
 
-        elif isinstance(self.parameters.Item(index).value, float):
-            p = RealParam(self.parameters.Item(index))
+            elif isinstance(self.parameters.Item(index).value, str):
+                p = StrParam(self.parameters.Item(index))
+
+            elif isinstance(self.parameters.Item(index).value, float):
+                p = RealParam(self.parameters.Item(index))
+
+            else:
+                raise CATIAApplicationException(f'Could not assign parameter name "{index}".')
 
         else:
-
-            raise CATIAApplicationException(f'Could not assign parameter name "{index}".')
+            p = ListParameter(self.parameters.Item(index))
 
         return p
 


### PR DESCRIPTION
Added support for lists. 
Previously would give error:

pycatia\knowledge_interfaces\parameters.py", line 443, in item
    if isinstance(self.parameters.Item(index).value, bool):

Example:

```
"""
Requirements:
Part with parameter set "Test" including a list.
"""

from pycatia import catia
from pycatia.knowledge_interfaces.list import List

caa = catia()
document = caa.active_document
part = document.part
part_parameters = part.parameters

root = part_parameters.root_parameter_set
main_set = root.parameter_sets.item("Test")

list_obj = main_set.direct_parameters.item(1)
list_obj = list_obj.value_list
list_obj = List(list_obj.com_object)
```