### PR TITLE
fix parameters.py: resolved errors in .item() function, extend and improve parsing of parameters

### DIFF
--- a/pycatia/knowledge_interfaces/parameters.py
+++ b/pycatia/knowledge_interfaces/parameters.py
@@ -59,23 +59,23 @@ def parse_to_parameter_subtype(com_object):
                 return ListParameter(com_object)
         except AttributeError:
             pass
- 
+
         try:
-          if isinstance(com_object.Value, bool):
-              return BoolParam(com_object)
+            if isinstance(com_object.Value, bool):
+                return BoolParam(com_object)
 
-          if isinstance(com_object.Value, int):
-              return IntParam(com_object)
+            if isinstance(com_object.Value, int):
+                return IntParam(com_object)
 
-          if isinstance(com_object.Value, str):
-              return StrParam(com_object)
+            if isinstance(com_object.Value, str):
+                return StrParam(com_object)
 
-          if isinstance(com_object.Value, float):
-              return RealParam(com_object)
+            if isinstance(com_object.Value, float):
+                return RealParam(com_object)
         except AttributeError:
             # Parameter has no Value either
             pass
-        
+
         return Parameter(com_object)
 
 


### PR DESCRIPTION
Proposed fix for https://github.com/evereux/pycatia/issues/197.


This uses a new way to obtain the com_class type to then map it to the correct parameter class.
This parsing is experimental but seems to work for most things.

Fallback is the previous parsing solution.