### PR TITLE
Add V5Automation case-compatible aliases

### DIFF
--- a/docs/api/pycatia/arrangement_interfaces/arr_bom_report.rst
+++ b/docs/api/pycatia/arrangement_interfaces/arr_bom_report.rst
@@ -1,3 +1,4 @@
+.. _ArrBOMReport:
 .. _ArrBomReport:
 
 pycatia.arrangement_interfaces.arr_bom_report

--- a/docs/api/pycatia/cat_ipd_adapter_interfaces/ipd_template_property.rst
+++ b/docs/api/pycatia/cat_ipd_adapter_interfaces/ipd_template_property.rst
@@ -1,3 +1,4 @@
+.. _IPDTemplateProperty:
 .. _IpdTemplateProperty:
 
 pycatia.cat_ipd_adapter_interfaces.ipd_template_property

--- a/docs/api/pycatia/cat_ipd_adapter_interfaces/mhi_relation_management.rst
+++ b/docs/api/pycatia/cat_ipd_adapter_interfaces/mhi_relation_management.rst
@@ -1,3 +1,4 @@
+.. _MHIRelationManagement:
 .. _MhiRelationManagement:
 
 pycatia.cat_ipd_adapter_interfaces.mhi_relation_management

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_app_factory.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_app_factory.rst
@@ -1,3 +1,4 @@
+.. _PspAppFactory:
 .. _PSPAppFactory:
 
 pycatia.cat_plant_ship_interfaces.psp_app_factory

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_application.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_application.rst
@@ -1,3 +1,4 @@
+.. _PspApplication:
 .. _PSPApplication:
 
 pycatia.cat_plant_ship_interfaces.psp_application

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_attribute.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_attribute.rst
@@ -1,3 +1,4 @@
+.. _PspAttribute:
 .. _PSPAttribute:
 
 pycatia.cat_plant_ship_interfaces.psp_attribute

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_attribute_report.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_attribute_report.rst
@@ -1,3 +1,4 @@
+.. _PspAttributeReport:
 .. _PSPAttributeReport:
 
 pycatia.cat_plant_ship_interfaces.psp_attribute_report

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_build_part.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_build_part.rst
@@ -1,3 +1,4 @@
+.. _PspBuildPart:
 .. _PSPBuildPart:
 
 pycatia.cat_plant_ship_interfaces.psp_build_part

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_class.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_class.rst
@@ -1,3 +1,4 @@
+.. _PspClass:
 .. _PSPClass:
 
 pycatia.cat_plant_ship_interfaces.psp_class

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_cntr_flow.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_cntr_flow.rst
@@ -1,3 +1,4 @@
+.. _PspCntrFlow:
 .. _PSPCntrFlow:
 
 pycatia.cat_plant_ship_interfaces.psp_cntr_flow

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_connectable.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_connectable.rst
@@ -1,3 +1,4 @@
+.. _PspConnectable:
 .. _PSPConnectable:
 
 pycatia.cat_plant_ship_interfaces.psp_connectable

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_connector.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_connector.rst
@@ -1,3 +1,4 @@
+.. _PspConnector:
 .. _PSPConnector:
 
 pycatia.cat_plant_ship_interfaces.psp_connector

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_functional.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_functional.rst
@@ -1,3 +1,4 @@
+.. _PspFunctional:
 .. _PSPFunctional:
 
 pycatia.cat_plant_ship_interfaces.psp_functional

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_group.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_group.rst
@@ -1,3 +1,4 @@
+.. _PspGroup:
 .. _PSPGroup:
 
 pycatia.cat_plant_ship_interfaces.psp_group

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_groupable.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_groupable.rst
@@ -1,3 +1,4 @@
+.. _PspGroupable:
 .. _PSPGroupable:
 
 pycatia.cat_plant_ship_interfaces.psp_groupable

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_id.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_id.rst
@@ -1,3 +1,4 @@
+.. _PspID:
 .. _PSPId:
 
 pycatia.cat_plant_ship_interfaces.psp_id

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_bend.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_bend.rst
@@ -1,3 +1,4 @@
+.. _PspLightBend:
 .. _PSPLightBend:
 
 pycatia.cat_plant_ship_interfaces.psp_light_bend

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_connector.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_connector.rst
@@ -1,3 +1,4 @@
+.. _PspLightConnector:
 .. _PSPLightConnector:
 
 pycatia.cat_plant_ship_interfaces.psp_light_connector

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_part.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_light_part.rst
@@ -1,3 +1,4 @@
+.. _PspLightPart:
 .. _PSPLightPart:
 
 pycatia.cat_plant_ship_interfaces.psp_light_part

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_bstrs.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_bstrs.rst
@@ -1,3 +1,4 @@
+.. _PspListOfBSTRs:
 .. _PSPListOfBSTRs:
 
 pycatia.cat_plant_ship_interfaces.psp_list_of_bstrs

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_doubles.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_doubles.rst
@@ -1,3 +1,4 @@
+.. _PspListOfDoubles:
 .. _PSPListOfDoubles:
 
 pycatia.cat_plant_ship_interfaces.psp_list_of_doubles

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_longs.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_longs.rst
@@ -1,3 +1,4 @@
+.. _PspListOfLongs:
 .. _PSPListOfLongs:
 
 pycatia.cat_plant_ship_interfaces.psp_list_of_longs

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_objects.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_list_of_objects.rst
@@ -1,3 +1,4 @@
+.. _PspListOfObjects:
 .. _PSPListOfObjects:
 
 pycatia.cat_plant_ship_interfaces.psp_list_of_objects

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_logical_line.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_logical_line.rst
@@ -1,3 +1,4 @@
+.. _PspLogicalLine:
 .. _PSPLogicalLine:
 
 pycatia.cat_plant_ship_interfaces.psp_logical_line

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_object.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_object.rst
@@ -1,3 +1,4 @@
+.. _PspObject:
 .. _PSPObject:
 
 pycatia.cat_plant_ship_interfaces.psp_object

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_part_connector.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_part_connector.rst
@@ -1,3 +1,4 @@
+.. _PspPartConnector:
 .. _PSPPartConnector:
 
 pycatia.cat_plant_ship_interfaces.psp_part_connector

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_phsyical_product.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_phsyical_product.rst
@@ -1,3 +1,4 @@
+.. _PspPhsyicalProduct:
 .. _PSPPhsyicalProduct:
 
 pycatia.cat_plant_ship_interfaces.psp_phsyical_product

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_physical.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_physical.rst
@@ -1,3 +1,4 @@
+.. _PspPhysical:
 .. _PSPPhysical:
 
 pycatia.cat_plant_ship_interfaces.psp_physical

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_place_part.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_place_part.rst
@@ -1,3 +1,4 @@
+.. _PspPlacePart:
 .. _PSPPlacePart:
 
 pycatia.cat_plant_ship_interfaces.psp_place_part

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_resource.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_resource.rst
@@ -1,3 +1,4 @@
+.. _PspResource:
 .. _PSPResource:
 
 pycatia.cat_plant_ship_interfaces.psp_resource

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_spatial.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_spatial.rst
@@ -1,3 +1,4 @@
+.. _PspSpatial:
 .. _PSPSpatial:
 
 pycatia.cat_plant_ship_interfaces.psp_spatial

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_stretchable_data.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_stretchable_data.rst
@@ -1,3 +1,4 @@
+.. _PspStretchableData:
 .. _PSPStretchableData:
 
 pycatia.cat_plant_ship_interfaces.psp_stretchable_data

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_temp_list_factory.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_temp_list_factory.rst
@@ -1,3 +1,4 @@
+.. _PspTempListFactory:
 .. _PSPTempListFactory:
 
 pycatia.cat_plant_ship_interfaces.psp_temp_list_factory

--- a/docs/api/pycatia/cat_plant_ship_interfaces/psp_workbench.rst
+++ b/docs/api/pycatia/cat_plant_ship_interfaces/psp_workbench.rst
@@ -1,3 +1,4 @@
+.. _PspWorkbench:
 .. _PSPWorkbench:
 
 pycatia.cat_plant_ship_interfaces.psp_workbench

--- a/docs/api/pycatia/cat_sm_interfaces/catalog_shm_object_setting_att.rst
+++ b/docs/api/pycatia/cat_sm_interfaces/catalog_shm_object_setting_att.rst
@@ -1,3 +1,4 @@
+.. _CatalogSHMObjectSettingAtt:
 .. _CatalogShmObjectSettingAtt:
 
 pycatia.cat_sm_interfaces.catalog_shm_object_setting_att

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_function_factory.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_function_factory.rst
@@ -1,3 +1,4 @@
+.. _SfmFunctionFactory:
 .. _SFMFunctionFactory:
 
 pycatia.cat_str_functional_interfaces.sfm_function_factory

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_opening.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_opening.rst
@@ -1,3 +1,4 @@
+.. _SfmOpening:
 .. _SFMOpening:
 
 pycatia.cat_str_functional_interfaces.sfm_opening

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_opening_contours_mgr.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_opening_contours_mgr.rst
@@ -1,3 +1,4 @@
+.. _SfmOpeningContoursMgr:
 .. _SFMOpeningContoursMgr:
 
 pycatia.cat_str_functional_interfaces.sfm_opening_contours_mgr

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_positioning_strategy_manager.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_positioning_strategy_manager.rst
@@ -1,3 +1,4 @@
+.. _SfmPositioningStrategyManager:
 .. _SFMPositioningStrategyManager:
 
 pycatia.cat_str_functional_interfaces.sfm_positioning_strategy_manager

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_references.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_references.rst
@@ -1,3 +1,4 @@
+.. _SfmReferences:
 .. _SFMReferences:
 
 pycatia.cat_str_functional_interfaces.sfm_references

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_contour_parameters.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_contour_parameters.rst
@@ -1,3 +1,4 @@
+.. _SfmStandardContourParameters:
 .. _SFMStandardContourParameters:
 
 pycatia.cat_str_functional_interfaces.sfm_standard_contour_parameters

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_opening.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_opening.rst
@@ -1,3 +1,4 @@
+.. _SfmStandardOpening:
 .. _SFMStandardOpening:
 
 pycatia.cat_str_functional_interfaces.sfm_standard_opening

--- a/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_pos_strategy_parameters.rst
+++ b/docs/api/pycatia/cat_str_functional_interfaces/sfm_standard_pos_strategy_parameters.rst
@@ -1,3 +1,4 @@
+.. _SfmStandardPosStrategyParameters:
 .. _SFMStandardPosStrategyParameters:
 
 pycatia.cat_str_functional_interfaces.sfm_standard_pos_strategy_parameters

--- a/docs/api/pycatia/cat_tps_interfaces/dmu_tol_setting_att.rst
+++ b/docs/api/pycatia/cat_tps_interfaces/dmu_tol_setting_att.rst
@@ -1,3 +1,4 @@
+.. _DMUTolSettingAtt:
 .. _DmuTolSettingAtt:
 
 pycatia.cat_tps_interfaces.dmu_tol_setting_att

--- a/docs/api/pycatia/cat_tps_interfaces/fta_infra_setting_att.rst
+++ b/docs/api/pycatia/cat_tps_interfaces/fta_infra_setting_att.rst
@@ -1,3 +1,4 @@
+.. _FTAInfraSettingAtt:
 .. _FtaInfraSettingAtt:
 
 pycatia.cat_tps_interfaces.fta_infra_setting_att

--- a/docs/api/pycatia/dnb_device_interfaces/dof_state.rst
+++ b/docs/api/pycatia/dnb_device_interfaces/dof_state.rst
@@ -1,3 +1,4 @@
+.. _DOFState:
 .. _DofState:
 
 pycatia.dnb_device_interfaces.dof_state

--- a/docs/api/pycatia/dnb_ehm_interfaces/ehm_insertion_act_plug_map_view_data.rst
+++ b/docs/api/pycatia/dnb_ehm_interfaces/ehm_insertion_act_plug_map_view_data.rst
@@ -1,3 +1,4 @@
+.. _EHMInsertionActPlugMapViewData:
 .. _EhmInsertionActPlugMapViewData:
 
 pycatia.dnb_ehm_interfaces.ehm_insertion_act_plug_map_view_data

--- a/docs/api/pycatia/dnb_ekp_interfaces/ekp_services.rst
+++ b/docs/api/pycatia/dnb_ekp_interfaces/ekp_services.rst
@@ -1,3 +1,4 @@
+.. _EKPServices:
 .. _EkpServices:
 
 pycatia.dnb_ekp_interfaces.ekp_services

--- a/docs/api/pycatia/dnb_fastener_interfaces/dnb_fastener_item_services.rst
+++ b/docs/api/pycatia/dnb_fastener_interfaces/dnb_fastener_item_services.rst
@@ -1,3 +1,4 @@
+.. _DNBFastenerItemServices:
 .. _DnbFastenerItemServices:
 
 pycatia.dnb_fastener_interfaces.dnb_fastener_item_services

--- a/docs/api/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment.rst
+++ b/docs/api/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment.rst
@@ -1,3 +1,4 @@
+.. _DNBAttachment:
 .. _DnbAttachment:
 
 pycatia.dnb_manufacturing_layout_interfaces.dnb_attachment

--- a/docs/api/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment_factory.rst
+++ b/docs/api/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment_factory.rst
@@ -1,3 +1,4 @@
+.. _DNBAttachmentFactory:
 .. _DnbAttachmentFactory:
 
 pycatia.dnb_manufacturing_layout_interfaces.dnb_attachment_factory

--- a/docs/api/pycatia/dnb_reporting_interfaces/fas_reporting_setting_att.rst
+++ b/docs/api/pycatia/dnb_reporting_interfaces/fas_reporting_setting_att.rst
@@ -1,3 +1,4 @@
+.. _FASReportingSettingAtt:
 .. _FasReportingSettingAtt:
 
 pycatia.dnb_reporting_interfaces.fas_reporting_setting_att

--- a/docs/api/pycatia/dnb_work_interfaces/wi_text_access_ei.rst
+++ b/docs/api/pycatia/dnb_work_interfaces/wi_text_access_ei.rst
@@ -1,3 +1,4 @@
+.. _WITextAccessEI:
 .. _WITextAccessEi:
 
 pycatia.dnb_work_interfaces.wi_text_access_ei

--- a/docs/api/pycatia/in_interfaces/cgr_adhesion_setting_att.rst
+++ b/docs/api/pycatia/in_interfaces/cgr_adhesion_setting_att.rst
@@ -1,3 +1,4 @@
+.. _CGRAdhesionSettingAtt:
 .. CgrAdhesionSettingAtt:
 
 pycatia.in_interfaces.cgr_adhesion_setting_att

--- a/docs/api/pycatia/in_interfaces/viewpoint_3d.rst
+++ b/docs/api/pycatia/in_interfaces/viewpoint_3d.rst
@@ -1,3 +1,4 @@
+.. _Viewpoint3D:
 .. _ViewPoint3D:
 
 pycatia.in_interfaces.viewpoint_3d

--- a/docs/api/pycatia/manufacturing_interfaces/manufacturing_apt_generator.rst
+++ b/docs/api/pycatia/manufacturing_interfaces/manufacturing_apt_generator.rst
@@ -1,3 +1,4 @@
+.. _ManufacturingAPTGenerator:
 .. _ManufacturingAptGenerator:
 
 pycatia.manufacturing_interfaces.manufacturing_apt_generator

--- a/docs/api/pycatia/manufacturing_interfaces/manufacturing_tool_motions.rst
+++ b/docs/api/pycatia/manufacturing_interfaces/manufacturing_tool_motions.rst
@@ -1,3 +1,4 @@
+.. _MfgToolMotions:
 .. _MFGToolMotions:
 
 pycatia.manufacturing_interfaces.manufacturing_tool_motions

--- a/docs/api/pycatia/structure_interfaces/material_ess_object_setting_att.rst
+++ b/docs/api/pycatia/structure_interfaces/material_ess_object_setting_att.rst
@@ -1,3 +1,4 @@
+.. _MaterialESSObjectSettingAtt:
 .. _MaterialEssObjectSettingAtt:
 
 pycatia.structure_interfaces.material_ess_object_setting_att

--- a/docs/api/pycatia/structure_interfaces/type_ess_object_setting_att.rst
+++ b/docs/api/pycatia/structure_interfaces/type_ess_object_setting_att.rst
@@ -1,3 +1,4 @@
+.. _TypeESSObjectSettingAtt:
 .. _TypeEssObjectSettingAtt:
 
 pycatia.structure_interfaces.type_ess_object_setting_att

--- a/docs/api/pycatia/system_interfaces/dl_name_setting_att.rst
+++ b/docs/api/pycatia/system_interfaces/dl_name_setting_att.rst
@@ -1,3 +1,4 @@
+.. _DLNameSettingAtt:
 .. _DlNameSettingAtt:
 
 pycatia.system_interfaces.dl_name_setting_att

--- a/docs/api/pycatia/system_interfaces/pcs_statistics_setting_att.rst
+++ b/docs/api/pycatia/system_interfaces/pcs_statistics_setting_att.rst
@@ -1,3 +1,4 @@
+.. _PCSStatisticsSettingAtt:
 .. _PcsStatisticsSettingAtt:
 
 pycatia.system_interfaces.pcs_statistics_setting_att

--- a/pycatia/arrangement_interfaces/arr_bom_report.py
+++ b/pycatia/arrangement_interfaces/arr_bom_report.py
@@ -69,3 +69,12 @@ class ArrBomReport(AnyObject):
 
     def __repr__(self):
         return f'ArrBomReport(name="{self.name}")'
+
+class ArrBOMReport(ArrBomReport):
+    """
+    V5Automation exposes this interface as ``ArrBOMReport``.
+    pycatia also keeps the existing ``ArrBomReport`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'ArrBOMReport(name="{self.name}")'

--- a/pycatia/cat_ipd_adapter_interfaces/ipd_template_property.py
+++ b/pycatia/cat_ipd_adapter_interfaces/ipd_template_property.py
@@ -146,3 +146,12 @@ class IpdTemplateProperty(AnyObject):
 
     def __repr__(self):
         return f'IpdTemplateProperty(name="{self.name}")'
+
+class IPDTemplateProperty(IpdTemplateProperty):
+    """
+    V5Automation exposes this interface as ``IPDTemplateProperty``.
+    pycatia also keeps the existing ``IpdTemplateProperty`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'IPDTemplateProperty(name="{self.name}")'

--- a/pycatia/cat_ipd_adapter_interfaces/mhi_relation_management.py
+++ b/pycatia/cat_ipd_adapter_interfaces/mhi_relation_management.py
@@ -104,3 +104,12 @@ class MhiRelationManagement(AnyObject):
 
     def __repr__(self):
         return f'MhiRelationManagement(name="{self.name}")'
+
+class MHIRelationManagement(MhiRelationManagement):
+    """
+    V5Automation exposes this interface as ``MHIRelationManagement``.
+    pycatia also keeps the existing ``MhiRelationManagement`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'MHIRelationManagement(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_app_factory.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_app_factory.py
@@ -460,3 +460,12 @@ class PSPAppFactory(AnyObject):
 
     def __repr__(self):
         return f'PSPAppFactory(name="{self.name}")'
+
+class PspAppFactory(PSPAppFactory):
+    """
+    V5Automation exposes this interface as ``PspAppFactory``.
+    pycatia also keeps the existing ``PSPAppFactory`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspAppFactory(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_application.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_application.py
@@ -68,3 +68,12 @@ class PSPApplication(AnyObject):
 
     def __repr__(self):
         return f'PSPApplication(name="{self.name}")'
+
+class PspApplication(PSPApplication):
+    """
+    V5Automation exposes this interface as ``PspApplication``.
+    pycatia also keeps the existing ``PSPApplication`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspApplication(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_attribute.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_attribute.py
@@ -427,3 +427,12 @@ class PSPAttribute(AnyObject):
 
     def __repr__(self):
         return f'PSPAttribute(name="{self.name}")'
+
+class PspAttribute(PSPAttribute):
+    """
+    V5Automation exposes this interface as ``PspAttribute``.
+    pycatia also keeps the existing ``PSPAttribute`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspAttribute(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_attribute_report.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_attribute_report.py
@@ -99,3 +99,12 @@ class PSPAttributeReport(AnyObject):
 
     def __repr__(self):
         return f'PSPAttributeReport(name="{self.name}")'
+
+class PspAttributeReport(PSPAttributeReport):
+    """
+    V5Automation exposes this interface as ``PspAttributeReport``.
+    pycatia also keeps the existing ``PSPAttributeReport`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspAttributeReport(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_build_part.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_build_part.py
@@ -197,3 +197,12 @@ class PSPBuildPart(AnyObject):
 
     def __repr__(self):
         return f'PSPBuildPart(name="{self.name}")'
+
+class PspBuildPart(PSPBuildPart):
+    """
+    V5Automation exposes this interface as ``PspBuildPart``.
+    pycatia also keeps the existing ``PSPBuildPart`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspBuildPart(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_class.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_class.py
@@ -107,3 +107,12 @@ class PSPClass(AnyObject):
 
     def __repr__(self):
         return f'PSPClass(name="{self.name}")'
+
+class PspClass(PSPClass):
+    """
+    V5Automation exposes this interface as ``PspClass``.
+    pycatia also keeps the existing ``PSPClass`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspClass(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_cntr_flow.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_cntr_flow.py
@@ -101,3 +101,12 @@ class PSPCntrFlow(AnyObject):
 
     def __repr__(self):
         return f'PSPCntrFlow(name="{self.name}")'
+
+class PspCntrFlow(PSPCntrFlow):
+    """
+    V5Automation exposes this interface as ``PspCntrFlow``.
+    pycatia also keeps the existing ``PSPCntrFlow`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspCntrFlow(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_connectable.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_connectable.py
@@ -196,3 +196,12 @@ class PSPConnectable(AnyObject):
 
     def __repr__(self):
         return f'PSPConnectable(name="{self.name}")'
+
+class PspConnectable(PSPConnectable):
+    """
+    V5Automation exposes this interface as ``PspConnectable``.
+    pycatia also keeps the existing ``PSPConnectable`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspConnectable(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_connector.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_connector.py
@@ -244,3 +244,12 @@ class PSPConnector(AnyObject):
 
     def __repr__(self):
         return f'PSPConnector(name="{self.name}")'
+
+class PspConnector(PSPConnector):
+    """
+    V5Automation exposes this interface as ``PspConnector``.
+    pycatia also keeps the existing ``PSPConnector`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspConnector(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_functional.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_functional.py
@@ -392,3 +392,12 @@ class PSPFunctional(AnyObject):
 
     def __repr__(self):
         return f'PSPFunctional(name="{self.name}")'
+
+class PspFunctional(PSPFunctional):
+    """
+    V5Automation exposes this interface as ``PspFunctional``.
+    pycatia also keeps the existing ``PSPFunctional`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspFunctional(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_group.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_group.py
@@ -145,3 +145,12 @@ class PSPGroup(AnyObject):
 
     def __repr__(self):
         return f'PSPGroup(name="{self.name}")'
+
+class PspGroup(PSPGroup):
+    """
+    V5Automation exposes this interface as ``PspGroup``.
+    pycatia also keeps the existing ``PSPGroup`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspGroup(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_groupable.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_groupable.py
@@ -63,3 +63,12 @@ class PSPGroupable(AnyObject):
 
     def __repr__(self):
         return f'PSPGroupable(name="{self.name}")'
+
+class PspGroupable(PSPGroupable):
+    """
+    V5Automation exposes this interface as ``PspGroupable``.
+    pycatia also keeps the existing ``PSPGroupable`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspGroupable(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_id.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_id.py
@@ -217,3 +217,12 @@ class PSPId(AnyObject):
 
     def __repr__(self):
         return f'PSPId(name="{self.name}")'
+
+class PspID(PSPId):
+    """
+    V5Automation exposes this interface as ``PspID``.
+    pycatia also keeps the existing ``PSPId`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspID(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_light_bend.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_light_bend.py
@@ -103,3 +103,12 @@ class PSPLightBend(AnyObject):
 
     def __repr__(self):
         return f'PSPLightBend(name="{self.name}")'
+
+class PspLightBend(PSPLightBend):
+    """
+    V5Automation exposes this interface as ``PspLightBend``.
+    pycatia also keeps the existing ``PSPLightBend`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspLightBend(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_light_connector.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_light_connector.py
@@ -282,3 +282,12 @@ class PSPLightConnector(AnyObject):
 
     def __repr__(self):
         return f'PSPLightConnector(name="{self.name}")'
+
+class PspLightConnector(PSPLightConnector):
+    """
+    V5Automation exposes this interface as ``PspLightConnector``.
+    pycatia also keeps the existing ``PSPLightConnector`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspLightConnector(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_light_part.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_light_part.py
@@ -121,3 +121,12 @@ class PSPLightPart(AnyObject):
 
     def __repr__(self):
         return f'PSPLightPart(name="{self.name}")'
+
+class PspLightPart(PSPLightPart):
+    """
+    V5Automation exposes this interface as ``PspLightPart``.
+    pycatia also keeps the existing ``PSPLightPart`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspLightPart(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_list_of_bstrs.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_list_of_bstrs.py
@@ -149,3 +149,12 @@ class PSPListOfBSTRs(AnyObject):
 
     def __repr__(self):
         return f'PSPListOfBstRs(name="{self.name}")'
+
+class PspListOfBSTRs(PSPListOfBSTRs):
+    """
+    V5Automation exposes this interface as ``PspListOfBSTRs``.
+    pycatia also keeps the existing ``PSPListOfBSTRs`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspListOfBSTRs(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_list_of_doubles.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_list_of_doubles.py
@@ -151,3 +151,12 @@ class PSPListOfDoubles(AnyObject):
 
     def __repr__(self):
         return f'PSPListOfDoubles(name="{self.name}")'
+
+class PspListOfDoubles(PSPListOfDoubles):
+    """
+    V5Automation exposes this interface as ``PspListOfDoubles``.
+    pycatia also keeps the existing ``PSPListOfDoubles`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspListOfDoubles(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_list_of_longs.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_list_of_longs.py
@@ -151,3 +151,12 @@ class PSPListOfLongs(AnyObject):
 
     def __repr__(self):
         return f'PSPListOfLongs(name="{self.name}")'
+
+class PspListOfLongs(PSPListOfLongs):
+    """
+    V5Automation exposes this interface as ``PspListOfLongs``.
+    pycatia also keeps the existing ``PSPListOfLongs`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspListOfLongs(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_list_of_objects.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_list_of_objects.py
@@ -152,3 +152,12 @@ class PSPListOfObjects(AnyObject):
 
     def __repr__(self):
         return f'PSPListOfObjects(name="{self.name}")'
+
+class PspListOfObjects(PSPListOfObjects):
+    """
+    V5Automation exposes this interface as ``PspListOfObjects``.
+    pycatia also keeps the existing ``PSPListOfObjects`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspListOfObjects(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_logical_line.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_logical_line.py
@@ -211,3 +211,12 @@ class PSPLogicalLine(PSPGroup):
 
     def __repr__(self):
         return f'PSPLogicalLine(name="{self.name}")'
+
+class PspLogicalLine(PSPLogicalLine):
+    """
+    V5Automation exposes this interface as ``PspLogicalLine``.
+    pycatia also keeps the existing ``PSPLogicalLine`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspLogicalLine(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_object.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_object.py
@@ -109,3 +109,12 @@ class PSPObject(AnyObject):
 
     def __repr__(self):
         return f'PSPObject(name="{self.name}")'
+
+class PspObject(PSPObject):
+    """
+    V5Automation exposes this interface as ``PspObject``.
+    pycatia also keeps the existing ``PSPObject`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspObject(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_part_connector.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_part_connector.py
@@ -580,3 +580,12 @@ class PSPPartConnector(AnyObject):
 
     def __repr__(self):
         return f'PSPPartConnector(name="{self.name}")'
+
+class PspPartConnector(PSPPartConnector):
+    """
+    V5Automation exposes this interface as ``PspPartConnector``.
+    pycatia also keeps the existing ``PSPPartConnector`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspPartConnector(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_phsyical_product.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_phsyical_product.py
@@ -186,3 +186,12 @@ class PSPPhsyicalProduct(AnyObject):
 
     def __repr__(self):
         return f'PSPPhsyicalProduct(name="{self.name}")'
+
+class PspPhsyicalProduct(PSPPhsyicalProduct):
+    """
+    V5Automation exposes this interface as ``PspPhsyicalProduct``.
+    pycatia also keeps the existing ``PSPPhsyicalProduct`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspPhsyicalProduct(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_physical.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_physical.py
@@ -87,3 +87,12 @@ class PSPPhysical(AnyObject):
 
     def __repr__(self):
         return f'PSPPhysical(name="{self.name}")'
+
+class PspPhysical(PSPPhysical):
+    """
+    V5Automation exposes this interface as ``PspPhysical``.
+    pycatia also keeps the existing ``PSPPhysical`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspPhysical(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_place_part.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_place_part.py
@@ -252,3 +252,12 @@ class PSPPlacePart(AnyObject):
 
     def __repr__(self):
         return f'PSPPlacePart(name="{self.name}")'
+
+class PspPlacePart(PSPPlacePart):
+    """
+    V5Automation exposes this interface as ``PspPlacePart``.
+    pycatia also keeps the existing ``PSPPlacePart`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspPlacePart(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_resource.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_resource.py
@@ -98,3 +98,12 @@ class PSPResource(AnyObject):
 
     def __repr__(self):
         return f'PSPResource(name="{self.name}")'
+
+class PspResource(PSPResource):
+    """
+    V5Automation exposes this interface as ``PspResource``.
+    pycatia also keeps the existing ``PSPResource`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspResource(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_spatial.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_spatial.py
@@ -116,3 +116,12 @@ class PSPSpatial(AnyObject):
 
     def __repr__(self):
         return f'PSPSpatial(name="{self.name}")'
+
+class PspSpatial(PSPSpatial):
+    """
+    V5Automation exposes this interface as ``PspSpatial``.
+    pycatia also keeps the existing ``PSPSpatial`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspSpatial(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_stretchable_data.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_stretchable_data.py
@@ -96,3 +96,12 @@ class PSPStretchableData(AnyObject):
 
     def __repr__(self):
         return f'PSPStretchableData(name="{self.name}")'
+
+class PspStretchableData(PSPStretchableData):
+    """
+    V5Automation exposes this interface as ``PspStretchableData``.
+    pycatia also keeps the existing ``PSPStretchableData`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspStretchableData(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_temp_list_factory.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_temp_list_factory.py
@@ -145,3 +145,12 @@ class PSPTempListFactory(AnyObject):
 
     def __repr__(self):
         return f'PSPTempListFactory(name="{self.name}")'
+
+class PspTempListFactory(PSPTempListFactory):
+    """
+    V5Automation exposes this interface as ``PspTempListFactory``.
+    pycatia also keeps the existing ``PSPTempListFactory`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspTempListFactory(name="{self.name}")'

--- a/pycatia/cat_plant_ship_interfaces/psp_workbench.py
+++ b/pycatia/cat_plant_ship_interfaces/psp_workbench.py
@@ -168,3 +168,12 @@ class PSPWorkbench(AnyObject):
 
     def __repr__(self):
         return f'PSPWorkbench(name="{self.name}")'
+
+class PspWorkbench(PSPWorkbench):
+    """
+    V5Automation exposes this interface as ``PspWorkbench``.
+    pycatia also keeps the existing ``PSPWorkbench`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PspWorkbench(name="{self.name}")'

--- a/pycatia/cat_sm_interfaces/catalog_shm_object_setting_att.py
+++ b/pycatia/cat_sm_interfaces/catalog_shm_object_setting_att.py
@@ -134,3 +134,12 @@ class CatalogShmObjectSettingAtt(SettingController):
 
     def __repr__(self):
         return f'CatalogShmObjectSettingAtt(name="{self.name}")'
+
+class CatalogSHMObjectSettingAtt(CatalogShmObjectSettingAtt):
+    """
+    V5Automation exposes this interface as ``CatalogSHMObjectSettingAtt``.
+    pycatia also keeps the existing ``CatalogShmObjectSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'CatalogSHMObjectSettingAtt(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_function_factory.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_function_factory.py
@@ -282,3 +282,12 @@ class SFMFunctionFactory(Factory):
 
     def __repr__(self):
         return f'SFMFunctionFactory(name="{self.name}")'
+
+class SfmFunctionFactory(SFMFunctionFactory):
+    """
+    V5Automation exposes this interface as ``SfmFunctionFactory``.
+    pycatia also keeps the existing ``SFMFunctionFactory`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmFunctionFactory(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_opening.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_opening.py
@@ -288,3 +288,12 @@ class SFMOpening(AnyObject):
 
     def __repr__(self):
         return f'SFMOpening(name="{self.name}")'
+
+class SfmOpening(SFMOpening):
+    """
+    V5Automation exposes this interface as ``SfmOpening``.
+    pycatia also keeps the existing ``SFMOpening`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmOpening(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_opening_contours_mgr.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_opening_contours_mgr.py
@@ -174,3 +174,12 @@ class SFMOpeningContoursMgr(AnyObject):
 
     def __repr__(self):
         return f'SFMOpeningContoursMgr(name="{self.name}")'
+
+class SfmOpeningContoursMgr(SFMOpeningContoursMgr):
+    """
+    V5Automation exposes this interface as ``SfmOpeningContoursMgr``.
+    pycatia also keeps the existing ``SFMOpeningContoursMgr`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmOpeningContoursMgr(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_positioning_strategy_manager.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_positioning_strategy_manager.py
@@ -156,3 +156,12 @@ class SFMPositioningStrategyManager(AnyObject):
 
     def __repr__(self):
         return f'SFMPositioningStrategyManager(name="{self.name}")'
+
+class SfmPositioningStrategyManager(SFMPositioningStrategyManager):
+    """
+    V5Automation exposes this interface as ``SfmPositioningStrategyManager``.
+    pycatia also keeps the existing ``SFMPositioningStrategyManager`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmPositioningStrategyManager(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_references.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_references.py
@@ -144,3 +144,12 @@ class SFMReferences(Collection):
 
     def __repr__(self):
         return f'SFMReferences(name="{self.name}")'
+
+class SfmReferences(SFMReferences):
+    """
+    V5Automation exposes this interface as ``SfmReferences``.
+    pycatia also keeps the existing ``SFMReferences`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmReferences(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_standard_contour_parameters.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_standard_contour_parameters.py
@@ -101,3 +101,12 @@ class SFMStandardContourParameters(Collection):
 
     def __repr__(self):
         return f'SFMStandardContourParameters(name="{self.name}")'
+
+class SfmStandardContourParameters(SFMStandardContourParameters):
+    """
+    V5Automation exposes this interface as ``SfmStandardContourParameters``.
+    pycatia also keeps the existing ``SFMStandardContourParameters`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmStandardContourParameters(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_standard_opening.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_standard_opening.py
@@ -318,3 +318,12 @@ class SFMStandardOpening(AnyObject):
 
     def __repr__(self):
         return f'SFMStandardOpening(name="{self.name}")'
+
+class SfmStandardOpening(SFMStandardOpening):
+    """
+    V5Automation exposes this interface as ``SfmStandardOpening``.
+    pycatia also keeps the existing ``SFMStandardOpening`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmStandardOpening(name="{self.name}")'

--- a/pycatia/cat_str_functional_interfaces/sfm_standard_pos_strategy_parameters.py
+++ b/pycatia/cat_str_functional_interfaces/sfm_standard_pos_strategy_parameters.py
@@ -296,3 +296,12 @@ class SFMStandardPosStrategyParameters(AnyObject):
 
     def __repr__(self):
         return f'SFMStandardPosStrategyParameters(name="{self.name}")'
+
+class SfmStandardPosStrategyParameters(SFMStandardPosStrategyParameters):
+    """
+    V5Automation exposes this interface as ``SfmStandardPosStrategyParameters``.
+    pycatia also keeps the existing ``SFMStandardPosStrategyParameters`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'SfmStandardPosStrategyParameters(name="{self.name}")'

--- a/pycatia/cat_tps_interfaces/dmu_tol_setting_att.py
+++ b/pycatia/cat_tps_interfaces/dmu_tol_setting_att.py
@@ -484,3 +484,36 @@ class DmuTolSettingAtt(SettingController):
 
     def __repr__(self):
         return f'DmuTolSettingAtt(name="{self.name}")'
+
+class DMUTolSettingAtt(DmuTolSettingAtt):
+    """
+    V5Automation exposes this interface as ``DMUTolSettingAtt``.
+    pycatia also keeps the existing ``DmuTolSettingAtt`` wrapper.
+    """
+
+    def get_related_colors(self, o_related_r: int, o_related_g: int, o_related_b: int) -> None:
+        """
+        Alias for :meth:`get_related_colours`.
+        """
+        return self.get_related_colours(o_related_r, o_related_g, o_related_b)
+
+    def get_related_colors_info(self, admin_level: str, o_locked: str) -> bool:
+        """
+        Alias for :meth:`get_related_colours_info`.
+        """
+        return self.get_related_colours_info(admin_level, o_locked)
+
+    def set_related_colors(self, i_related_r: int, i_related_g: int, i_related_b: int) -> None:
+        """
+        Alias for :meth:`set_related_colours`.
+        """
+        return self.set_related_colours(i_related_r, i_related_g, i_related_b)
+
+    def set_related_colors_lock(self, i_locked: bool) -> None:
+        """
+        Alias for :meth:`set_related_colours_lock`.
+        """
+        return self.set_related_colours_lock(i_locked)
+
+    def __repr__(self):
+        return f'DMUTolSettingAtt(name="{self.name}")'

--- a/pycatia/cat_tps_interfaces/fta_infra_setting_att.py
+++ b/pycatia/cat_tps_interfaces/fta_infra_setting_att.py
@@ -1683,3 +1683,24 @@ class FtaInfraSettingAtt(SettingController):
 
     def __repr__(self):
         return f'FtaInfraSettingAtt(name="{self.name}")'
+
+class FTAInfraSettingAtt(FtaInfraSettingAtt):
+    """
+    V5Automation exposes this interface as ``FTAInfraSettingAtt``.
+    pycatia also keeps the existing ``FtaInfraSettingAtt`` wrapper.
+    """
+
+    def get_man_ref_siz_info(self, admin_level: str, o_locked: str) -> bool:
+        """
+        Alias for :meth:`get_man_ref_size_info`.
+        """
+        return self.get_man_ref_size_info(admin_level, o_locked)
+
+    def set_man_ref_siz_lock(self, i_locked: bool) -> None:
+        """
+        Alias for :meth:`set_man_ref_size_lock`.
+        """
+        return self.set_man_ref_size_lock(i_locked)
+
+    def __repr__(self):
+        return f'FTAInfraSettingAtt(name="{self.name}")'

--- a/pycatia/dnb_device_interfaces/dof_state.py
+++ b/pycatia/dnb_device_interfaces/dof_state.py
@@ -92,3 +92,12 @@ class DofState(AnyObject):
 
     def __repr__(self):
         return f'DofState(name="{self.name}")'
+
+class DOFState(DofState):
+    """
+    V5Automation exposes this interface as ``DOFState``.
+    pycatia also keeps the existing ``DofState`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'DOFState(name="{self.name}")'

--- a/pycatia/dnb_ehm_interfaces/ehm_insertion_act_plug_map_view_data.py
+++ b/pycatia/dnb_ehm_interfaces/ehm_insertion_act_plug_map_view_data.py
@@ -920,3 +920,19 @@ class EhmInsertionActPlugMapViewData(Activity):
 
     def __repr__(self):
         return f'EhmInsertionActPlugMapViewData(name="{self.name}")'
+
+class EHMInsertionActPlugMapViewData(EhmInsertionActPlugMapViewData):
+    """
+    V5Automation exposes this interface as ``EHMInsertionActPlugMapViewData``.
+    pycatia also keeps the existing ``EhmInsertionActPlugMapViewData`` wrapper.
+    """
+
+    @property
+    def wire_color(self) -> str:
+        """
+        Alias for :attr:`wire_colour`.
+        """
+        return self.wire_colour
+
+    def __repr__(self):
+        return f'EHMInsertionActPlugMapViewData(name="{self.name}")'

--- a/pycatia/dnb_ehs_interfaces/ehs_update_smoothness_factor.py
+++ b/pycatia/dnb_ehs_interfaces/ehs_update_smoothness_factor.py
@@ -70,3 +70,12 @@ class EhsUpdateSmoothnessFactor(AnyObject):
 
     def __repr__(self):
         return f'EhsUpdateSmoothnessFactor(name="{self.name}")'
+
+class EHSUpdateSmoothnessFactor(EhsUpdateSmoothnessFactor):
+    """
+    V5Automation exposes this interface as ``EHSUpdateSmoothnessFactor``.
+    pycatia also keeps the existing ``EhsUpdateSmoothnessFactor`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'EHSUpdateSmoothnessFactor(name="{self.name}")'

--- a/pycatia/dnb_ekp_interfaces/ekp_services.py
+++ b/pycatia/dnb_ekp_interfaces/ekp_services.py
@@ -293,3 +293,12 @@ class EkpServices(AnyObject):
 
     def __repr__(self):
         return f'EkpServices(name="{self.name}")'
+
+class EKPServices(EkpServices):
+    """
+    V5Automation exposes this interface as ``EKPServices``.
+    pycatia also keeps the existing ``EkpServices`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'EKPServices(name="{self.name}")'

--- a/pycatia/dnb_fastener_interfaces/dnb_fastener_item_services.py
+++ b/pycatia/dnb_fastener_interfaces/dnb_fastener_item_services.py
@@ -345,3 +345,12 @@ class DnbFastenerItemServices(AnyObject):
 
     def __repr__(self):
         return f'DnbFastenerItemServices(name="{self.name}")'
+
+class DNBFastenerItemServices(DnbFastenerItemServices):
+    """
+    V5Automation exposes this interface as ``DNBFastenerItemServices``.
+    pycatia also keeps the existing ``DnbFastenerItemServices`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'DNBFastenerItemServices(name="{self.name}")'

--- a/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment.py
+++ b/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment.py
@@ -249,3 +249,12 @@ class DnbAttachment(AnyObject):
 
     def __repr__(self):
         return f'DnbAttachment(name="{self.name}")'
+
+class DNBAttachment(DnbAttachment):
+    """
+    V5Automation exposes this interface as ``DNBAttachment``.
+    pycatia also keeps the existing ``DnbAttachment`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'DNBAttachment(name="{self.name}")'

--- a/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment_factory.py
+++ b/pycatia/dnb_manufacturing_layout_interfaces/dnb_attachment_factory.py
@@ -97,3 +97,12 @@ class DnbAttachmentFactory(AnyObject):
 
     def __repr__(self):
         return f'DnbAttachmentFactory(name="{self.name}")'
+
+class DNBAttachmentFactory(DnbAttachmentFactory):
+    """
+    V5Automation exposes this interface as ``DNBAttachmentFactory``.
+    pycatia also keeps the existing ``DnbAttachmentFactory`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'DNBAttachmentFactory(name="{self.name}")'

--- a/pycatia/dnb_reporting_interfaces/fas_reporting_setting_att.py
+++ b/pycatia/dnb_reporting_interfaces/fas_reporting_setting_att.py
@@ -755,3 +755,12 @@ class FasReportingSettingAtt(SettingController):
 
     def __repr__(self):
         return f'FasReportingSettingAtt(name="{self.name}")'
+
+class FASReportingSettingAtt(FasReportingSettingAtt):
+    """
+    V5Automation exposes this interface as ``FASReportingSettingAtt``.
+    pycatia also keeps the existing ``FasReportingSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'FASReportingSettingAtt(name="{self.name}")'

--- a/pycatia/dnb_work_interfaces/wi_text_access_ei.py
+++ b/pycatia/dnb_work_interfaces/wi_text_access_ei.py
@@ -87,3 +87,29 @@ class WITextAccessEi(AnyObject):
 
     def __repr__(self):
         return f'WITextAccessEi(name="{self.name}")'
+
+class WITextAccessEI(WITextAccessEi):
+    """
+    V5Automation exposes this interface as ``WITextAccessEI``.
+    pycatia also keeps the existing ``WITextAccessEi`` wrapper.
+    """
+
+    def get_geom_refered_by_annotation(
+            self,
+            i_opor_act: int,
+            i_assigned_ei_index: int,
+            i_assignment_type: int,
+            io_point_geom: AnyObject
+    ) -> None:
+        """
+        Alias for :meth:`get_geom_referred_by_annotation`.
+        """
+        return self.get_geom_referred_by_annotation(
+            i_opor_act,
+            i_assigned_ei_index,
+            i_assignment_type,
+            io_point_geom
+        )
+
+    def __repr__(self):
+        return f'WITextAccessEI(name="{self.name}")'

--- a/pycatia/in_interfaces/cgr_adhesion_setting_att.py
+++ b/pycatia/in_interfaces/cgr_adhesion_setting_att.py
@@ -411,3 +411,12 @@ class CgrAdhesionSettingAtt(SettingController):
 
     def __repr__(self):
         return f'CgrAdhesionSettingAtt(name="{ self.name }")'
+
+class CGRAdhesionSettingAtt(CgrAdhesionSettingAtt):
+    """
+    V5Automation exposes this interface as ``CGRAdhesionSettingAtt``.
+    pycatia also keeps the existing ``CgrAdhesionSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'CGRAdhesionSettingAtt(name="{self.name}")'

--- a/pycatia/in_interfaces/viewpoint_3d.py
+++ b/pycatia/in_interfaces/viewpoint_3d.py
@@ -390,3 +390,12 @@ class ViewPoint3D(AnyObject):
 
     def __repr__(self):
         return f'ViewPoint3D(name="{self.name}")'
+
+class Viewpoint3D(ViewPoint3D):
+    """
+    V5Automation exposes this interface as ``Viewpoint3D``.
+    pycatia also keeps the existing ``ViewPoint3D`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'Viewpoint3D(name="{self.name}")'

--- a/pycatia/manufacturing_interfaces/manufacturing_apt_generator.py
+++ b/pycatia/manufacturing_interfaces/manufacturing_apt_generator.py
@@ -39,3 +39,12 @@ class ManufacturingAptGenerator(ManufacturingOutputGenerator):
 
     def __repr__(self):
         return f'ManufacturingAptGenerator(name="{self.name}")'
+
+class ManufacturingAPTGenerator(ManufacturingAptGenerator):
+    """
+    V5Automation exposes this interface as ``ManufacturingAPTGenerator``.
+    pycatia also keeps the existing ``ManufacturingAptGenerator`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'ManufacturingAPTGenerator(name="{self.name}")'

--- a/pycatia/manufacturing_interfaces/manufacturing_tool_motions.py
+++ b/pycatia/manufacturing_interfaces/manufacturing_tool_motions.py
@@ -97,3 +97,12 @@ class MFGToolMotions(Collection):
 
     def __repr__(self):
         return f'MfgToolMotions(name="{self.name}")'
+
+class MfgToolMotions(MFGToolMotions):
+    """
+    V5Automation exposes this interface as ``MfgToolMotions``.
+    pycatia also keeps the existing ``MFGToolMotions`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'MfgToolMotions(name="{self.name}")'

--- a/pycatia/structure_interfaces/material_ess_object_setting_att.py
+++ b/pycatia/structure_interfaces/material_ess_object_setting_att.py
@@ -243,3 +243,12 @@ class MaterialEssObjectSettingAtt(SettingController):
 
     def __repr__(self):
         return f'MaterialEssObjectSettingAtt(name="{self.name}")'
+
+class MaterialESSObjectSettingAtt(MaterialEssObjectSettingAtt):
+    """
+    V5Automation exposes this interface as ``MaterialESSObjectSettingAtt``.
+    pycatia also keeps the existing ``MaterialEssObjectSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'MaterialESSObjectSettingAtt(name="{self.name}")'

--- a/pycatia/structure_interfaces/type_ess_object_setting_att.py
+++ b/pycatia/structure_interfaces/type_ess_object_setting_att.py
@@ -243,3 +243,12 @@ class TypeEssObjectSettingAtt(SettingController):
 
     def __repr__(self):
         return f'TypeEssObjectSettingAtt(name="{self.name}")'
+
+class TypeESSObjectSettingAtt(TypeEssObjectSettingAtt):
+    """
+    V5Automation exposes this interface as ``TypeESSObjectSettingAtt``.
+    pycatia also keeps the existing ``TypeEssObjectSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'TypeESSObjectSettingAtt(name="{self.name}")'

--- a/pycatia/system_interfaces/dl_name_setting_att.py
+++ b/pycatia/system_interfaces/dl_name_setting_att.py
@@ -578,3 +578,12 @@ class DlNameSettingAtt(SettingController):
 
     def __repr__(self):
         return f'DlNameSettingAtt(name="{self.name}")'
+
+class DLNameSettingAtt(DlNameSettingAtt):
+    """
+    V5Automation exposes this interface as ``DLNameSettingAtt``.
+    pycatia also keeps the existing ``DlNameSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'DLNameSettingAtt(name="{self.name}")'

--- a/pycatia/system_interfaces/pcs_statistics_setting_att.py
+++ b/pycatia/system_interfaces/pcs_statistics_setting_att.py
@@ -77,3 +77,12 @@ class PcsStatisticsSettingAtt(GeneralStatisticsSettingAtt):
 
     def __repr__(self):
         return f'PcsStatisticsSettingAtt(name="{ self.name }")'
+
+class PCSStatisticsSettingAtt(PcsStatisticsSettingAtt):
+    """
+    V5Automation exposes this interface as ``PCSStatisticsSettingAtt``.
+    pycatia also keeps the existing ``PcsStatisticsSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PCSStatisticsSettingAtt(name="{self.name}")'


### PR DESCRIPTION
Adds V5Automation-compatible class names for wrappers that already exist in pycatia with different acronym casing.

This keeps the existing pycatia class names in place and adds subclass aliases such as `DMUTolSettingAtt` for `DmuTolSettingAtt`.

Also adds a few spelling-compatible forwarding methods/properties where the existing wrapper uses pycatia naming but V5Automation exposes a different spelling:

- `related_colors` forwards to `related_colours`
- `man_ref_siz` forwards to `man_ref_size`
- `wire_color` forwards to `wire_colour`
- `get_geom_refered_by_annotation` forwards to `get_geom_referred_by_annotation`

Validation run:

- `py -3.12 -m compileall <changed-python-files>`
- manifest import/member check for 62 aliases
- alias forwarding smoke check
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`
- live CATIA connection smoke check: `CATIA.Application` returned `CNEXT`