### PR TITLE
Add ControledRadius alias

### DIFF
--- a/docs/api/pycatia/cat_tps_interfaces/controlled_radius.rst
+++ b/docs/api/pycatia/cat_tps_interfaces/controlled_radius.rst
@@ -1,3 +1,4 @@
+.. _ControledRadius:
 .. _ControlledRadius:
 
 pycatia.cat_tps_interfaces.controlled_radius

--- a/pycatia/cat_tps_interfaces/controlled_radius.py
+++ b/pycatia/cat_tps_interfaces/controlled_radius.py
@@ -54,3 +54,13 @@ class ControlledRadius(AnyObject):
 
     def __repr__(self):
         return f'ControlledRadius(name="{self.name}")'
+
+
+class ControledRadius(ControlledRadius):
+    """
+    V5Automation exposes this interface as ``ControledRadius``.
+    pycatia also keeps the existing ``ControlledRadius`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'ControledRadius(name="{self.name}")'


### PR DESCRIPTION
Adds the V5Automation spelling `ControledRadius` as a compatibility alias for the existing `ControlledRadius` wrapper.

The existing wrapper already documents the V5Automation interface as `ControledRadius`, and already exposes the `modifier` property. This change keeps `ControlledRadius` in place and adds a subclass with the V5Automation class name.

Validation run:

- `py -3.12 -m compileall pycatia\cat_tps_interfaces\controlled_radius.py`
- import check for `ControlledRadius` and `ControledRadius`
- manifest exact-name check confirms `ControledRadius` is no longer missing
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`