### PR TITLE
Add EnvelopCondition alias

### DIFF
--- a/docs/api/pycatia/cat_tps_interfaces/envelope_condition.rst
+++ b/docs/api/pycatia/cat_tps_interfaces/envelope_condition.rst
@@ -1,3 +1,4 @@
+.. _EnvelopCondition:
 .. _EnvelopeCondition:
 
 pycatia.cat_tps_interfaces.envelope_condition

--- a/pycatia/cat_tps_interfaces/envelope_condition.py
+++ b/pycatia/cat_tps_interfaces/envelope_condition.py
@@ -52,3 +52,13 @@ class EnvelopeCondition(AnyObject):
 
     def __repr__(self):
         return f'EnvelopCondition(name="{self.name}")'
+
+
+class EnvelopCondition(EnvelopeCondition):
+    """
+    V5Automation exposes this interface as ``EnvelopCondition``.
+    pycatia also keeps the existing ``EnvelopeCondition`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'EnvelopCondition(name="{self.name}")'


### PR DESCRIPTION
Adds the V5Automation spelling `EnvelopCondition` as a compatibility alias for the existing `EnvelopeCondition` wrapper.

The existing wrapper already documents the V5Automation interface as `EnvelopCondition` and exposes the `modifier` property. This change keeps `EnvelopeCondition` in place and adds a subclass with the V5Automation class name.

Validation run:

- `py -3.12 -m compileall pycatia\cat_tps_interfaces\envelope_condition.py`
- import check for `EnvelopeCondition` and `EnvelopCondition`
- manifest exact-name check confirms `EnvelopCondition` is no longer missing
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`