### PR TITLE
Add SchAppCntrColor alias

### DIFF
--- a/docs/api/pycatia/cat_sch_platform_interfaces/sch_app_cntr_colour.rst
+++ b/docs/api/pycatia/cat_sch_platform_interfaces/sch_app_cntr_colour.rst
@@ -1,3 +1,4 @@
+.. _SchAppCntrColor:
 .. _SchAppCntrColour:
 
 pycatia.cat_sch_platform_interfaces.sch_app_cntr_colour

--- a/pycatia/cat_sch_platform_interfaces/sch_app_cntr_colour.py
+++ b/pycatia/cat_sch_platform_interfaces/sch_app_cntr_colour.py
@@ -66,3 +66,19 @@ class SchAppCntrColour(AnyObject):
 
     def __repr__(self):
         return f'SchAppCntrColour(name="{self.name}")'
+
+
+class SchAppCntrColor(SchAppCntrColour):
+    """
+    V5Automation exposes this interface as ``SchAppCntrColor``.
+    pycatia also keeps the existing ``SchAppCntrColour`` wrapper.
+    """
+
+    def app_get_connector_color_by_type(self, o_color: int) -> None:
+        """
+        Alias for :meth:`app_get_connector_colour_by_type`.
+        """
+        return self.app_get_connector_colour_by_type(o_color)
+
+    def __repr__(self):
+        return f'SchAppCntrColor(name="{self.name}")'


### PR DESCRIPTION
Adds the V5Automation spelling `SchAppCntrColor` as a compatibility alias for the existing `SchAppCntrColour` wrapper.

The existing wrapper already documents the V5Automation interface as `SchAppCntrColor`. This change keeps `SchAppCntrColour` in place and adds:

- `SchAppCntrColor`
- `app_get_connector_color_by_type`, forwarding to `app_get_connector_colour_by_type`

Validation run:

- `py -3.12 -m compileall pycatia\cat_sch_platform_interfaces\sch_app_cntr_colour.py`
- import check for `SchAppCntrColour` and `SchAppCntrColor`
- manifest method check for `AppGetConnectorColorByType`
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`