### PR TITLE
Add PathESSRessourcesSettingAtt alias

### DIFF
--- a/docs/api/pycatia/structure_interfaces/path_ess_resources_setting_att.rst
+++ b/docs/api/pycatia/structure_interfaces/path_ess_resources_setting_att.rst
@@ -1,3 +1,4 @@
+.. _PathESSRessourcesSettingAtt:
 .. _PathEssResourcesSettingAtt:
 
 pycatia.structure_interfaces.path_ess_resources_setting_att

--- a/pycatia/structure_interfaces/path_ess_resources_setting_att.py
+++ b/pycatia/structure_interfaces/path_ess_resources_setting_att.py
@@ -346,3 +346,13 @@ class PathEssResourcesSettingAtt(SettingController):
 
     def __repr__(self):
         return f'PathEssResourcesSettingAtt(name="{self.name}")'
+
+
+class PathESSRessourcesSettingAtt(PathEssResourcesSettingAtt):
+    """
+    V5Automation exposes this interface as ``PathESSRessourcesSettingAtt``.
+    pycatia also keeps the existing ``PathEssResourcesSettingAtt`` wrapper.
+    """
+
+    def __repr__(self):
+        return f'PathESSRessourcesSettingAtt(name="{self.name}")'


### PR DESCRIPTION
Adds the V5Automation spelling `PathESSRessourcesSettingAtt` as a compatibility alias for the existing `PathEssResourcesSettingAtt` wrapper.

The existing wrapper already documents the V5Automation interface as `PathESSRessourcesSettingAtt` and exposes the required path properties and lock/info methods. This change keeps `PathEssResourcesSettingAtt` in place and adds a subclass with the V5Automation class name.

Validation run:

- `py -3.12 -m compileall pycatia\structure_interfaces\path_ess_resources_setting_att.py`
- import/member check for `PathEssResourcesSettingAtt` and `PathESSRessourcesSettingAtt`
- manifest exact-name check confirms `PathESSRessourcesSettingAtt` is no longer missing
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`