### PR TITLE
Add V4MasterModel wrapper

### DIFF
--- a/docs/api/index_catia_v4_interfaces.rst
+++ b/docs/api/index_catia_v4_interfaces.rst
@@ -9,5 +9,6 @@ pycatia.catia_v4_interfaces
    pycatia/catia_v4_interfaces/interop_setting_att
    pycatia/catia_v4_interfaces/migr_batch_setting_att
    pycatia/catia_v4_interfaces/spec_v4_setting_att
+   pycatia/catia_v4_interfaces/v4_master_model
    pycatia/catia_v4_interfaces/v4_v5_space_setting_att
    pycatia/catia_v4_interfaces/v4_writing_setting_att

--- a/docs/api/pycatia/catia_v4_interfaces/v4_master_model.rst
+++ b/docs/api/pycatia/catia_v4_interfaces/v4_master_model.rst
@@ -1,0 +1,7 @@
+.. _V4MasterModel:
+
+pycatia.catia_v4_interfaces.v4_master_model
+============================================
+
+.. automodule:: pycatia.catia_v4_interfaces.v4_master_model
+    :members:

--- a/pycatia/catia_v4_interfaces/v4_master_model.py
+++ b/pycatia/catia_v4_interfaces/v4_master_model.py
@@ -1,0 +1,56 @@
+#! usr/bin/python3.9
+"""
+    Module initially auto generated using V5Automation files from CATIA V5 R28 on 2020-09-25 14:34:21.593357
+
+    .. warning::
+        The notes denoted "CAA V5 Visual Basic Help" are to be used as reference only.
+        They are there as a guide as to how the visual basic / catscript functions work
+        and thus help debugging in pycatia.
+
+"""
+
+from pycatia.in_interfaces.document import Document
+from pycatia.system_interfaces.any_object import AnyObject
+
+
+class V4MasterModel(AnyObject):
+    """
+        .. note::
+            :class: toggle
+
+            CAA V5 Visual Basic Help (2020-09-25 14:34:21.593357)
+
+                | System.IUnknown
+                |     System.IDispatch
+                |         System.CATBaseUnknown
+                |             System.CATBaseDispatch
+                |                 System.AnyObject
+                |                     V4MasterModel
+                |
+                | Represents the V4 Master Model.
+                | The Master is the root container of a V4 Model.
+
+    """
+
+    def __init__(self, com_object):
+        super().__init__(com_object)
+        self.v4_master_model = com_object
+
+    @property
+    def v4_document_model(self) -> Document:
+        """
+        .. note::
+            :class: toggle
+
+            CAA V5 Visual Basic Help (2020-09-25 14:34:21.593357)
+                | o Property V4DocumentModel() As Document (Read Only)
+                |
+                |     Returns the V4 Document that contains the Master's Model.
+
+        :rtype: Document
+        """
+
+        return Document(self.v4_master_model.V4DocumentModel)
+
+    def __repr__(self):
+        return f'V4MasterModel(name="{self.name}")'


### PR DESCRIPTION
Adds a wrapper for the CATIAV4Interfaces `V4MasterModel` object.

This is not a compatibility alias for an existing pycatia wrapper. I checked the current tree and did not find an existing wrapper for this interface.

The wrapper exposes the read-only `v4_document_model` property and returns a pycatia `Document`.

Usage:

```python
from pycatia.catia_v4_interfaces.v4_master_model import V4MasterModel

v4_master = V4MasterModel(com_object)
v4_document = v4_master.v4_document_model
```

Validation run:

- `py -3.12 -m compileall pycatia\catia_v4_interfaces\v4_master_model.py`
- fake COM check for `v4_document_model`
- manifest exact-name check confirms `V4MasterModel` is present
- `py -3.12 -m pytest tests\in\test_unit_convertions.py`
- `git diff --check`