### PR TITLE
Skip optional exchange file tests when files are missing

### DIFF
--- a/tests/in/test_document.py
+++ b/tests/in/test_document.py
@@ -21,6 +21,15 @@ junk_folder = os.path.join(os.getcwd(), "__junk__/")
 now_string = datetime.now().strftime("%Y%m%d-%H%M%S")
 os.makedirs(junk_folder, exist_ok=True)
 
+igs_file_param = pytest.param(
+    igs_file,
+    marks=pytest.mark.skipif(not igs_file.is_file(), reason="part_measurable.igs is not available")
+)
+stp_file_param = pytest.param(
+    stp_file,
+    marks=pytest.mark.skipif(not stp_file.is_file(), reason="part_measurable.stp is not available")
+)
+
 
 @pytest.mark.parametrize('file_name', [cat_part_measurable])
 def test_activate_document(document_close_all_open):
@@ -157,18 +166,14 @@ def test_open_document_str(document_open_test_close):
     assert type(part_document) is PartDocument
 
 
-@pytest.mark.parametrize('file_name', [igs_file])
+@pytest.mark.parametrize('file_name', [igs_file_param])
 def test_open_document_igs(document_open_test_close):
-    # todo: igs file currently needs to be created manually.
     document = application.active_document
     assert type(document) is PartDocument
 
 
-@pytest.mark.parametrize('file_name', [stp_file])
+@pytest.mark.parametrize('file_name', [stp_file_param])
 def test_open_document_stp(document_open_test_close):
-    # stp file will need to be created manually.
-    if not stp_file.is_file():
-        assert False
     document = application.active_document
     assert type(document) is PartDocument
 
@@ -185,20 +190,14 @@ def test_read_document_strget_application(document_open_test_close):
     assert type(document) is PartDocument
 
 
-@pytest.mark.parametrize('file_name', [igs_file])
+@pytest.mark.parametrize('file_name', [igs_file_param])
 def test_read_document_igs(document_open_test_close):
-    # igs file will need to be created manually.
-    if not igs_file.is_file():
-        assert False
     document = application.active_document
     assert type(document) is PartDocument
 
 
-@pytest.mark.parametrize('file_name', [stp_file])
+@pytest.mark.parametrize('file_name', [stp_file_param])
 def test_read_document_stp(document_open_test_close):
-    # stp file will need to be created manually.
-    if not stp_file.is_file():
-        assert False
     document = application.active_document
     assert type(document) is PartDocument
 


### PR DESCRIPTION
What changed
- Marked the IGS and STP document tests as skipped when their optional source files are not present.
- Removed the manual `assert False` checks for the missing STP/IGS files.

Why
- `tests/cat_files/part_measurable.igs` and `tests/cat_files/part_measurable.stp` are not generated by the test setup.
- When those optional files are absent, the tests fail during fixture setup with `FileNotFoundError` before the test body can run.

Validation
- CATIA V5 was running locally on Windows in English.
- `py -3.12 -m pytest tests/in/test_document.py::test_open_document_igs tests/in/test_document.py::test_open_document_stp tests/in/test_document.py::test_read_document_igs tests/in/test_document.py::test_read_document_stp -q`
- Result before: `4 errors`
- Result after: `4 skipped`
- `py -3.12 -m pytest tests/in/test_document.py -q`
- Result: `17 passed, 4 skipped`
- `py -3.12 -m compileall tests\in\test_document.py`
- `git diff --check`