### PR TITLE
Set child_object for typed collections

### DIFF
--- a/pycatia/cat_tps_interfaces/assembly_annotation_sets.py
+++ b/pycatia/cat_tps_interfaces/assembly_annotation_sets.py
@@ -36,8 +36,7 @@ class AssemblyAnnotationSets(Collection):
     """
 
     def __init__(self, com_object):
-        # todo: what is the child_object for Collection?
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=AnnotationSet)
         self.assembly_annotation_sets = com_object
 
     def item(self, i_index: CATVariant) -> AnyObject:

--- a/pycatia/knowledge_interfaces/optimization_constraints.py
+++ b/pycatia/knowledge_interfaces/optimization_constraints.py
@@ -34,7 +34,7 @@ class OptimizationConstraints(Collection):
     """
 
     def __init__(self, com_object):
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=OptimizationConstraint)
         self.optimization_constraints = com_object
 
     def add_constraint(self, constraint_expression: str) -> OptimizationConstraint:

--- a/pycatia/product_structure_interfaces/publications.py
+++ b/pycatia/product_structure_interfaces/publications.py
@@ -40,7 +40,7 @@ class Publications(Collection):
     """
 
     def __init__(self, com_object):
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=Publication)
         self.publications = com_object
 
     def add(self, i_public_name: str) -> Publication:

--- a/pycatia/space_analyses_interfaces/clash_results.py
+++ b/pycatia/space_analyses_interfaces/clash_results.py
@@ -41,7 +41,7 @@ class ClashResults(Collection):
     """
 
     def __init__(self, com_object):
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=ClashResult)
         self.clash_results = com_object
 
     def add_from_xml(self, i_path: str, i_type: int) -> ClashResult:

--- a/pycatia/space_analyses_interfaces/clashes.py
+++ b/pycatia/space_analyses_interfaces/clashes.py
@@ -38,7 +38,7 @@ class Clashes(Collection):
     """
 
     def __init__(self, com_object):
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=Clash)
         self.clashes = com_object
 
     def add(self) -> Clash:

--- a/pycatia/space_analyses_interfaces/conflicts.py
+++ b/pycatia/space_analyses_interfaces/conflicts.py
@@ -35,7 +35,7 @@ class Conflicts(Collection):
     """
 
     def __init__(self, com_object):
-        super().__init__(com_object)
+        super().__init__(com_object, child_object=Conflict)
         self.conflicts = com_object
 
     def item(self, i_index: CATVariant) -> Conflict:


### PR DESCRIPTION
What changed

- Set `child_object` for six typed collection wrappers that were still using the default `AnyObject` child wrapper.
- Affected collections: `AssemblyAnnotationSets`, `OptimizationConstraints`, `Publications`, `Clashes`, `ClashResults`, and `Conflicts`.

Why

- These collections already return typed wrappers from `item()` and `__getitem__()`.
- Their `__iter__()` methods use `self.child_object`, so iteration returned `AnyObject` unless `child_object` was set during initialization.
- This continues the existing `child_object` cleanup in `developement` without adding new public API names.

Validation

- `py -3.12 -m compileall pycatia\cat_tps_interfaces\assembly_annotation_sets.py pycatia\knowledge_interfaces\optimization_constraints.py pycatia\product_structure_interfaces\publications.py pycatia\space_analyses_interfaces\clashes.py pycatia\space_analyses_interfaces\clash_results.py pycatia\space_analyses_interfaces\conflicts.py`
- `git diff --check upstream/developement...HEAD`
- Ran a small fake COM collection script to verify iteration returns the expected wrapper type for each changed collection.
