### PR TITLE
Fix CatalogDocument return values for CreateCatalogFromLibrary and CreateCatalogFromcsv

### DIFF
--- a/pycatia/components_catalogs_interfaces/catalog_document.py
+++ b/pycatia/components_catalogs_interfaces/catalog_document.py
@@ -52,7 +52,7 @@ class CatalogDocument(Document):
                                     i_catalog_path: str,
                                     i_table_path: str,
                                     i_conv_format: int,
-                                    i_batch_mode: int) -> 'CatalogDocument':
+                                    i_batch_mode: int) -> None:
         """
         .. note::
             :class: toggle
@@ -97,16 +97,15 @@ class CatalogDocument(Document):
         :param int i_batch_mode:
         :rtype: None
         """
-        return CatalogDocument(
-            self.catalog_document.CreateCatalogFromLibrary(
-                i_library_path,
-                i_project_path,
-                i_catalog_path,
-                i_table_path,
-                i_conv_format,
-                i_batch_mode).com_object)
+        return self.catalog_document.CreateCatalogFromLibrary(
+            i_library_path,
+            i_project_path,
+            i_catalog_path,
+            i_table_path,
+            i_conv_format,
+            i_batch_mode)
 
-    def create_catalog_from_csv(self, i_init_data: str, i_new_catalog: str) -> 'CatalogDocument':
+    def create_catalog_from_csv(self, i_init_data: str, i_new_catalog: str) -> None:
         """
         .. note::
             :class: toggle
@@ -140,7 +139,7 @@ class CatalogDocument(Document):
         :param str i_init_data:
         :param str i_new_catalog:
         :return: None
-        :rtype: CatalogDocument
+        :rtype: None
         """
         return self.catalog_document.CreateCatalogFromcsv(i_init_data, i_new_catalog)
 


### PR DESCRIPTION
`CatalogDocument.create_catalog_from_library()` raises `AttributeError` on every call, and `create_catalog_from_csv()` is annotated with a return type it cannot return.

Both underlying CAA methods are `Sub`s, so they return nothing:

```
o Sub CreateCatalogFromLibrary(CATBSTR iLibraryPath, ...)
o Sub CreateCatalogFromcsv(CATBSTR iInitData, CATBSTR iNewCatalog)
```

### 1. `create_catalog_from_library` — `AttributeError`

```python
return CatalogDocument(
    self.catalog_document.CreateCatalogFromLibrary(...).com_object)
```

`CreateCatalogFromLibrary` returns `None`, so `.com_object` raises `AttributeError: 'NoneType' object has no attribute 'com_object'`. The method cannot succeed as written.

### 2. `create_catalog_from_csv` — annotation contradicts the docstring

Annotated `-> 'CatalogDocument'` while its own docstring says `:return: None`. It does return `None`.

### Usage

```python
from pycatia import catia

caa = catia()
catalog = caa.documents.add("CatalogDocument")

# returns None, as the CAA Sub does
result = catalog.create_catalog_from_csv(
    r"C:\path\to\BatchCatalog.csv",
    r"C:\path\to\Catalog_Result.catalog",
)
assert result is None
```

### Testing

`create_catalog_from_csv` is verified against CATIA V5R32 and V5R34 — the call returns `None` on both.

**`create_catalog_from_library` is reasoned, not tested.** I have no V4 library or project to migrate, so I could not exercise it. The existing code cannot work regardless, since `.com_object` is accessed on the return value of a `Sub`, but I would rather state that plainly than imply I ran it.

### Changelog

I have not touched `CHANGELOG.md` as there is no unreleased section and I did not want to guess the next version number. Happy to add an entry if you tell me which heading it belongs under.
